### PR TITLE
Add definition for ListGroundstationPlans API.

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -35,7 +35,7 @@ option java_package = "com.stellarstation.api.v1";
 // satellite pair.
 //
 // A plan is a scheduled pass that will be executed to send and receive data between the ground
-// stationand satellite during the time range.
+// station and satellite during the time range.
 service StellarStationService {
   // Lists the plans for a particular ground station.
   //

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -39,7 +39,7 @@ option java_package = "com.stellarstation.api.v1";
 service StellarStationService {
   // Lists the plans for a particular ground station.
   //
-  // The request will be closed with an `INVALID_ARGUMENT` status if `ground station_id`,
+  // The request will be closed with an `INVALID_ARGUMENT` status if `ground_station_id`,
   // `aos_after`, or `aos_before` are missing, or the duration between the two times is longer than
   // 31 days.
   rpc ListGroundStationPlans (ListGroundStationPlansRequest) returns (ListGroundStationPlansResponse);
@@ -186,8 +186,8 @@ message ListGroundStationPlansRequest {
   google.protobuf.Timestamp aos_after = 2;
 
 
-  // The end time of the range of plans to list (inclusive). Only plans with an Acquisition of
-  // Signal (AOS) at or before this time will be returned. It is an error for the duration between
+  // The end time of the range of plans to list (exclusive). Only plans with an Acquisition of
+  // Signal (AOS) before this time will be returned. It is an error for the duration between
   // `aos_after` and `aos_before` to be longer than 31 days.
   google.protobuf.Timestamp aos_before = 3;
 }

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -209,14 +209,17 @@ message Plan {
     // The plan has been scheduled and will be executed at `aos_time`.
     RESERVED = 0;
 
+    // The plan is currently executing.
+    EXECUTING = 1;
+
     // The plan has executed successfully.
-    SUCCEEDED = 1;
+    SUCCEEDED = 2;
 
     // The plan has executed but was not successful.
-    FAILED = 2;
+    FAILED = 3;
 
     // The plan has been cancelled and will not be executed.
-    CANCELLED = 3;
+    CANCELLED = 4;
   }
   // The status of this plan.
   Status status = 2;

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -29,7 +29,21 @@ option java_package = "com.stellarstation.api.v1";
 // satellites that the operator does not own or passes they have not reserved.
 // Only using IDs shown on the StellarStation Console or returned in API responses will ensure all
 // inputs are valid.
+//
+// A pass is a time range where an groundstation and satellite can communicate with each other, i.e.,
+// the period between Acquisition of Signal (AOS) and Loss of Signal (LOS) of the groundstation and
+// satellite pair.
+//
+// A plan is a scheduled pass that will be executed to send and receive data between the antenna
+// and satellite during the time range.
 service StellarStationService {
+  // Lists the plans for a particular groundstation.
+  //
+  // The request will be closed with an `INVALID_ARGUMENT` status if `groundstation_id`,
+  // `aos_after`, or `aos_before` are missing, or the duration between the two times is longer than
+  // 31 days.
+  rpc ListGroundstationPlans (ListGroundstationPlansRequest) returns (ListGroundstationPlansResponse);
+
   // Open a stream to a satellite. The returned stream is bi-directional - it can be used by the
   // client to send commands to the satellite and data received from the satellite will be returned
   // as it is made available. All telemetry received from the satellite on reserved passes from this
@@ -49,6 +63,10 @@ service StellarStationService {
   // with a `NOT_FOUND` error.
   rpc OpenSatelliteStream (stream SatelliteStreamRequest) returns (stream SatelliteStreamResponse);
 }
+
+//----------------------------------------------------------------------------------------------
+// Streaming APIs.
+//----------------------------------------------------------------------------------------------
 
 // Request for the `OpenSatelliteStream` method.
 message SatelliteStreamRequest {
@@ -150,4 +168,82 @@ message Telemetry {
   // * AX25 - This is either Address + Control, or Address + Control + PID. The checksum is not
   //          returned.
   bytes frame_header = 6;
+}
+
+//----------------------------------------------------------------------------------------------
+// Scheduling APIs.
+//----------------------------------------------------------------------------------------------
+
+// Request for the `ListGroundstationPlans` method.
+message ListGroundstationPlansRequest {
+  // The ID of the groundstation to list plans for. The ID can be found on the StellarStation
+  // Console page for the groundstation.
+  string groundstation_id = 1;
+
+  // The start time of the range of plans to list. Only plans with an Acquisition of Signal (AOS)
+  // at or after this time will be returned. It is an error for the duration between `aos_from` and
+  // `los_from` to be longer than 31 days.
+  google.protobuf.Timestamp aos_after = 2;
+
+
+  // The end time of the range of plans to list. Only plans with an Acquisition of Signal (AOS)
+  // at or before this time will be returned. It is an error for the duration between `aos_from` and
+  // `los_from` to be longer than 31 days.
+  google.protobuf.Timestamp aos_before = 3;
+}
+
+// A response from the `ListGroundstationPlans` method.
+message ListGroundstationPlansResponse {
+  // The requested list of plans for the groundstation.
+  repeated Plan plan = 1;
+}
+
+// A scheduled pass. The plan will be executed on its groundstation to communicate with its satellite
+// during a time range between AOS and LOS, unless explicitly cancelled.
+message Plan {
+  // The ID of this plan.
+  string plan_id = 1;
+
+  // Status of a plan.
+  enum Status {
+    // The plan has been scheduled and will be executed at `aos_time`.
+    RESERVED = 0;
+
+    // The plan has executed successfully.
+    SUCCEEDED = 1;
+
+    // The plan has executed but was not successful.
+    FAILED = 2;
+
+    // The plan has been cancelled and will not be executed.
+    CANCELLED = 3;
+  }
+  // The status of this plan.
+  Status status = 2;
+
+  // The TLE used to compute this plan. Always has exactly two items corresponding to line 1 and
+  // line 2 of the 2-line TLE format.
+  //
+  // https://en.wikipedia.org/wiki/Two-line_element_set
+  repeated string tle_line = 3;
+
+  // The time of AOS between the groundstation and satellite in this plan.
+  google.protobuf.Timestamp aos_time = 4;
+
+  // The time of LOS between the groundstation and satellite in this plan.
+  google.protobuf.Timestamp los_time = 5;
+
+  // The center frequency, in Hz, for downlinking in this plan. 0 if downlink is not available in
+  // this plan.
+  uint64 downlink_center_frequency_hz = 6;
+
+  // The center frequency, in Hz, for uplinking in this plan. 0 if uplink is not available in this
+  // plan.
+  uint64 uplink_center_frequency_hz = 7;
+
+  // The max elevation of the plan, in degrees.
+  double max_elevation_degrees = 8;
+
+  // The time of max elevation during the plan.
+  google.protobuf.Timestamp max_elevation_time = 9;
 }

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -25,24 +25,24 @@ option java_outer_classname = "StellarstationProto";
 option java_package = "com.stellarstation.api.v1";
 
 // The public API service of Stellarstation, a system supporting communication between satellites
-// and groundstations. This API is for use by an operator of a satellite - it is invalid to specify
-// satellites that the operator does not own or passes they have not reserved.
+// and ground stations. This API is for use by an operator of a satellite - it is invalid to specify
+// satellites that the operator does not own or plans they have not reserved.
 // Only using IDs shown on the StellarStation Console or returned in API responses will ensure all
 // inputs are valid.
 //
-// A pass is a time range where an groundstation and satellite can communicate with each other, i.e.,
-// the period between Acquisition of Signal (AOS) and Loss of Signal (LOS) of the groundstation and
+// A pass is a time range where an ground station and satellite can communicate with each other, i.e.,
+// the period between Acquisition of Signal (AOS) and Loss of Signal (LOS) of the ground station and
 // satellite pair.
 //
-// A plan is a scheduled pass that will be executed to send and receive data between the antenna
-// and satellite during the time range.
+// A plan is a scheduled pass that will be executed to send and receive data between the ground
+// stationand satellite during the time range.
 service StellarStationService {
-  // Lists the plans for a particular groundstation.
+  // Lists the plans for a particular ground station.
   //
-  // The request will be closed with an `INVALID_ARGUMENT` status if `groundstation_id`,
+  // The request will be closed with an `INVALID_ARGUMENT` status if `ground station_id`,
   // `aos_after`, or `aos_before` are missing, or the duration between the two times is longer than
   // 31 days.
-  rpc ListGroundstationPlans (ListGroundstationPlansRequest) returns (ListGroundstationPlansResponse);
+  rpc ListGroundStationPlans (ListGroundStationPlansRequest) returns (ListGroundStationPlansResponse);
 
   // Open a stream to a satellite. The returned stream is bi-directional - it can be used by the
   // client to send commands to the satellite and data received from the satellite will be returned
@@ -175,30 +175,30 @@ message Telemetry {
 //----------------------------------------------------------------------------------------------
 
 // Request for the `ListGroundstationPlans` method.
-message ListGroundstationPlansRequest {
-  // The ID of the groundstation to list plans for. The ID can be found on the StellarStation
-  // Console page for the groundstation.
-  string groundstation_id = 1;
+message ListGroundStationPlansRequest {
+  // The ID of the ground station to list plans for. The ID can be found on the StellarStation
+  // Console page for the ground station.
+  string ground_station_id = 1;
 
-  // The start time of the range of plans to list. Only plans with an Acquisition of Signal (AOS)
-  // at or after this time will be returned. It is an error for the duration between `aos_after` and
-  // `aos_before` to be longer than 31 days.
+  // The start time of the range of plans to list (inclusive). Only plans with an Acquisition of
+  // Signal (AOS) at or after this time will be returned. It is an error for the duration between
+  // `aos_after` and `aos_before` to be longer than 31 days.
   google.protobuf.Timestamp aos_after = 2;
 
 
-  // The end time of the range of plans to list. Only plans with an Acquisition of Signal (AOS)
-  // at or before this time will be returned. It is an error for the duration between `aos_after`
-  // and `aos_before` to be longer than 31 days.
+  // The end time of the range of plans to list (inclusive). Only plans with an Acquisition of
+  // Signal (AOS) at or before this time will be returned. It is an error for the duration between
+  // `aos_after` and `aos_before` to be longer than 31 days.
   google.protobuf.Timestamp aos_before = 3;
 }
 
 // A response from the `ListGroundstationPlans` method.
-message ListGroundstationPlansResponse {
-  // The requested list of plans for the groundstation.
+message ListGroundStationPlansResponse {
+  // The requested list of plans for the ground station.
   repeated Plan plan = 1;
 }
 
-// A scheduled pass. The plan will be executed on its groundstation to communicate with its satellite
+// A scheduled pass. The plan will be executed on its ground station to communicate with its satellite
 // during a time range between AOS and LOS, unless explicitly cancelled.
 message Plan {
   // The ID of this plan.
@@ -230,10 +230,10 @@ message Plan {
   // https://en.wikipedia.org/wiki/Two-line_element_set
   repeated string tle_line = 3;
 
-  // The time of AOS between the groundstation and satellite in this plan.
+  // The time of AOS between the ground station and satellite in this plan.
   google.protobuf.Timestamp aos_time = 4;
 
-  // The time of LOS between the groundstation and satellite in this plan.
+  // The time of LOS between the ground station and satellite in this plan.
   google.protobuf.Timestamp los_time = 5;
 
   // The center frequency, in Hz, for downlinking in this plan. 0 if downlink is not available in

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -181,14 +181,14 @@ message ListGroundstationPlansRequest {
   string groundstation_id = 1;
 
   // The start time of the range of plans to list. Only plans with an Acquisition of Signal (AOS)
-  // at or after this time will be returned. It is an error for the duration between `aos_from` and
-  // `los_from` to be longer than 31 days.
+  // at or after this time will be returned. It is an error for the duration between `aos_after` and
+  // `aos_before` to be longer than 31 days.
   google.protobuf.Timestamp aos_after = 2;
 
 
   // The end time of the range of plans to list. Only plans with an Acquisition of Signal (AOS)
-  // at or before this time will be returned. It is an error for the duration between `aos_from` and
-  // `los_from` to be longer than 31 days.
+  // at or before this time will be returned. It is an error for the duration between `aos_after`
+  // and `aos_before` to be longer than 31 days.
   google.protobuf.Timestamp aos_before = 3;
 }
 


### PR DESCRIPTION
I think we were leaning towards using `plan` instead of `scheduled pass` in the API, but let me know what you think.