### PR TITLE
Make sure groundstation.proto has same directory structure as its pro…

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
@@ -20,7 +20,7 @@ import "google/protobuf/timestamp.proto";
 
 package stellarstation.api.v1.groundstation;
 
-option go_package = "stellarstation/groundstation";
+option go_package = "groundstation";
 
 option java_multiple_files = true;
 option java_outer_classname = "GroundStationProto";


### PR DESCRIPTION
…to package.

Realized that I needed to fix the file system and go_package for it to be right in C++ and Go