### PR TITLE
Replace frequency in plans with detailed protocol information which i…

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
@@ -92,11 +92,11 @@ message Plan {
 
   // Configuration of the radio device used for downlinking from the satellite. Ground stations will
   // need to configure reception during the plan to match this device.
-  radio.RadioDeviceConfiguration satellite_downlink_radio_device = 5;
+  radio.RadioDeviceConfiguration downlink_radio_device = 5;
 
   // Configuration of the radio device used for uplinking to the satellite. Ground stations will
   // need to configure transmission during the plan to match this device.
-  radio.RadioDeviceConfiguration satellite_uplink_radio_device = 6;
+  radio.RadioDeviceConfiguration uplink_radio_device = 6;
 }
 
 // Unparsed TLE data for a satellite - https://en.wikipedia.org/wiki/Two-line_element_set

--- a/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
@@ -90,13 +90,13 @@ message Plan {
   // The time of LOS between the ground station and satellite in this plan.
   google.protobuf.Timestamp los_time = 4;
 
-  // Specification of the radio device used for downlinking from the satellite. Ground stations will
+  // Configuration of the radio device used for downlinking from the satellite. Ground stations will
   // need to configure reception during the plan to match this device.
-  radio.RadioDevice satellite_downlink_radio_device = 5;
+  radio.RadioDeviceConfiguration satellite_downlink_radio_device = 5;
 
-  // Specification of the radio device used for uplinking to the satellite. Ground stations will
+  // Configuration of the radio device used for uplinking to the satellite. Ground stations will
   // need to configure transmission during the plan to match this device.
-  radio.RadioDevice satellite_uplink_radio_device = 6;
+  radio.RadioDeviceConfiguration satellite_uplink_radio_device = 6;
 }
 
 // Unparsed TLE data for a satellite - https://en.wikipedia.org/wiki/Two-line_element_set

--- a/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
@@ -17,6 +17,7 @@
 syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
+import "stellarstation/api/v1/radio/radio.proto";
 
 package stellarstation.api.v1.groundstation;
 
@@ -89,13 +90,13 @@ message Plan {
   // The time of LOS between the ground station and satellite in this plan.
   google.protobuf.Timestamp los_time = 4;
 
-  // The center frequency, in Hz, for downlinking in this plan. 0 if downlink is not available in
-  // this plan.
-  uint64 downlink_center_frequency_hz = 5;
+  // Specification of the radio device used for downlinking from the satellite. Ground stations will
+  // need to configure reception during the plan to match this device.
+  radio.RadioDevice satellite_downlink_radio_device = 5;
 
-  // The center frequency, in Hz, for uplinking in this plan. 0 if uplink is not available in this
-  // plan.
-  uint64 uplink_center_frequency_hz = 6;
+  // Specification of the radio device used for uplinking to the satellite. Ground stations will
+  // need to configure transmission during the plan to match this device.
+  radio.RadioDevice satelltie_uplink_radio_device = 6;
 }
 
 // Unparsed TLE data for a satellite - https://en.wikipedia.org/wiki/Two-line_element_set

--- a/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
@@ -96,7 +96,7 @@ message Plan {
 
   // Specification of the radio device used for uplinking to the satellite. Ground stations will
   // need to configure transmission during the plan to match this device.
-  radio.RadioDevice satelltie_uplink_radio_device = 6;
+  radio.RadioDevice satellite_uplink_radio_device = 6;
 }
 
 // Unparsed TLE data for a satellite - https://en.wikipedia.org/wiki/Two-line_element_set

--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -24,13 +24,13 @@ option java_multiple_files = true;
 option java_outer_classname = "RadioProto";
 option java_package = "com.stellarstation.api.v1.radio";
 
-// Messages for modeling radio devices (e.g., receivers, transmitters) in API messages.
+// Messages for modeling radio device (e.g., receivers, transmitters) configuration in API messages.
 
 // A radio device for RF communication. Usually, a satellite will have one or more radio devices for
 // communicating with the ground and a ground station will have one or more radio devices for
 // communicating with the satellite. Such devices may not actually correspond to actual hardware
 // devices, i.e., in the case of Software Defined Radio (SDR).
-message RadioDevice {
+message RadioDeviceConfiguration {
   // The center frequency of the device, in Hz.
   uint64 center_frequency_hz = 1;
 

--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -34,25 +34,25 @@ message RadioDeviceConfiguration {
   // The center frequency of the device, in Hz.
   uint64 center_frequency_hz = 1;
 
-  // The protocol used by this device when doing RF communication.
-  CommunicationProtocol protocol = 2;
+  // The type of modulation used by this radio device.
+  Modulation modulation = 2;
+
+  // The bitrate used during modulation.
+  uint64 bitrate = 3;
+
+  // The protocol used by this device when doing RF communication. If unset, the device is only
+  // demodulating / modulating without applying any higher-level communication protocol.
+  CommunicationProtocol protocol = 4;
 }
 
 // A communication protocol used with a radio device. These must contain all the parameters
 // needed to configure the device for use either in transmission or reception.
 message CommunicationProtocol {
-  // The type of modulation used by this radio device.
-  Modulation modulation = 1;
-
-  // The bitrate to use during modulation.
-  uint64 bitrate = 2;
-
   // The type of framing used for communication on the device. If `bitstream`, the device is only
   // demodulating / modulating without applying any higher-level framing (i.e., packeting) protocol.
   oneof Framing {
-    BitStream bitstream = 3;
-
-    AX25 ax25 = 4;
+    // AX.25 protocol settings.
+    AX25 ax25 = 1;
   }
 }
 

--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -78,7 +78,8 @@ message Ax25 {
   uint32 source_ssid = 6;
 }
 
-  // Type of modulation.
+// Type of modulation. Modulation is the process of converting binary data (0's and 1's) to
+// an analog wave for use in radio communication.
 enum Modulation {
   // Frequency Shift Keying. https://en.wikipedia.org/wiki/Frequency-shift_keying
   FSK = 0;

--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2018 Infostellar, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+package stellarstation.api.v1.radio;
+
+option go_package = "radio";
+
+option java_multiple_files = true;
+option java_outer_classname = "RadioProto";
+option java_package = "com.stellarstation.api.v1.radio";
+
+// Messages for modeling radio devices (e.g., receivers, transmitters) in API messages.
+
+// A radio device for RF communication. Usually, a satellite will have one or more radio devices for
+// communicating with the ground and a ground station will have one or more radio devices for
+// communicating with the satellite. Such devices may not actually correspond to actual hardware
+// devices, i.e., in the case of Software Defined Radio (SDR).
+message RadioDevice {
+  // The center frequency of the device, in Hz.
+  uint64 center_frequency_hz = 1;
+
+  // The protocol used by this device when doing RF communication.
+  CommunicationProtocol protocol = 2;
+}
+
+// A communication protocol used with a radio device. These must contain all the parameters
+// needed to configure the device for use either in transmission or reception.
+message CommunicationProtocol {
+
+  // The type of modulation used by this radio device.
+  Modulation modulation = 1;
+
+  // The type of framing used for communication on the device. If `bitstream`, the device is only
+  // demodulating / modulating without applying any higher-level framing (i.e., packeting) protocol.
+  oneof Framing {
+    BitStream bitstream = 2;
+
+    Ax25 ax25 = 3;
+  }
+}
+
+// Communication of a stream of bits with no framing defined.
+message BitStream {
+}
+
+// PACKET communication based on AX.25. https://www.sigidwiki.com/wiki/PACKET.
+message Ax25 {
+  // Bit rate, e.g. 9600 for FSK9600, 1200 for AFSK1200.
+  uint64 bit_rate = 1;
+
+  // Whether or not G3RUH scrambling is used.
+  bool g3ruh = 2;
+
+  // Destination callsign.
+  string destination_callsign = 3;
+
+  // Destination SSID.
+  uint32 destination_ssid = 4;
+
+  // Source callsign.
+  string source_callsign = 5;
+
+  // Source SSID.
+  uint32 source_ssid = 6;
+}
+
+  // Type of modulation.
+enum Modulation {
+  // Frequency Shift Keying. https://en.wikipedia.org/wiki/Frequency-shift_keying
+  FSK = 0;
+
+  // Audio Frequency Shift Keying. https://en.wikipedia.org/wiki/Frequency-shift_keying#Audio_FSK
+  AFSK = 1;
+
+  // Binary Phase Shift Keying. https://en.wikipedia.org/wiki/Phase-shift_keying#Binary_phase-shift_keying_(BPSK)
+  BPSK = 2;
+}

--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -41,7 +41,6 @@ message RadioDevice {
 // A communication protocol used with a radio device. These must contain all the parameters
 // needed to configure the device for use either in transmission or reception.
 message CommunicationProtocol {
-
   // The type of modulation used by this radio device.
   Modulation modulation = 1;
 

--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -44,12 +44,15 @@ message CommunicationProtocol {
   // The type of modulation used by this radio device.
   Modulation modulation = 1;
 
+  // The bitrate to use during modulation.
+  uint64 bitrate = 2;
+
   // The type of framing used for communication on the device. If `bitstream`, the device is only
   // demodulating / modulating without applying any higher-level framing (i.e., packeting) protocol.
   oneof Framing {
-    BitStream bitstream = 2;
+    BitStream bitstream = 3;
 
-    AX25 ax25 = 3;
+    AX25 ax25 = 4;
   }
 }
 
@@ -59,23 +62,20 @@ message BitStream {
 
 // PACKET communication based on AX.25. https://www.sigidwiki.com/wiki/PACKET.
 message AX25 {
-  // Bit rate, e.g. 9600 for FSK9600, 1200 for AFSK1200.
-  uint64 bit_rate = 1;
-
   // Whether or not G3RUH scrambling is used.
-  bool g3ruh = 2;
+  bool g3ruh = 1;
 
   // Destination callsign.
-  string destination_callsign = 3;
+  string destination_callsign = 2;
 
   // Destination SSID.
-  uint32 destination_ssid = 4;
+  uint32 destination_ssid = 3;
 
   // Source callsign.
-  string source_callsign = 5;
+  string source_callsign = 4;
 
   // Source SSID.
-  uint32 source_ssid = 6;
+  uint32 source_ssid = 5;
 }
 
 // Type of modulation. Modulation is the process of converting binary data (0's and 1's) to

--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -49,7 +49,7 @@ message CommunicationProtocol {
   oneof Framing {
     BitStream bitstream = 2;
 
-    Ax25 ax25 = 3;
+    AX25 ax25 = 3;
   }
 }
 
@@ -58,7 +58,7 @@ message BitStream {
 }
 
 // PACKET communication based on AX.25. https://www.sigidwiki.com/wiki/PACKET.
-message Ax25 {
+message AX25 {
   // Bit rate, e.g. 9600 for FSK9600, 1200 for AFSK1200.
   uint64 bit_rate = 1;
 


### PR DESCRIPTION
…s required for actually configuring ground stations.

Frequency is generally not enough to configure a ground station for communication with a satellite, so return all the configuration instead.