### PR TITLE
Improve C++ stub publishing

### DIFF
--- a/stubs/cpp/build.gradle
+++ b/stubs/cpp/build.gradle
@@ -52,11 +52,28 @@ protobuf {
 
 }
 
-task downloadConanDeps {
-    dependsOn ':installPythonTools'
+task prepareConanfilePy {
+    inputs.property("version", version);
+    inputs.file("package/conanfile.py.tmpl")
+    outputs.file("$buildDir/generated/scripts/conanfile.py")
 
-    inputs.file 'conanfile.py'
-    outputs.dir 'build/conan/bin'
+    doFirst {
+        def template = file('package/conanfile.py.tmpl').text
+        def filled = template.replaceFirst('\\|API_VERSION\\|', version.toString())
+        def outDir = "$buildDir/generated/scripts"
+        mkdir outDir
+        def out = file("${outDir}/conanfile.py")
+        out.text = filled
+        out.executable = true
+    }
+}
+
+task downloadConanDeps {
+    dependsOn prepareConanfilePy, ':installPythonTools'
+
+    inputs.file "$buildDir/generated/scripts/conanfile.py"
+    inputs.file "package/src"
+    outputs.dir 'build/conan'
 
     def conanDir = file('build/conan')
     doFirst {
@@ -64,14 +81,20 @@ task downloadConanDeps {
         file("${conanDir}/src").mkdirs()
 
         copy {
-            from 'package'
+            from "$buildDir/generated/scripts/conanfile.py"
             into conanDir
+        }
+
+        copy {
+            from 'package/src'
+            into "$conanDir/src"
         }
 
         exec {
             executable 'bash'
             args '-c', condaCommand(
                     'conan remote add -f bincrafters https://api.bintray.com/conan/bincrafters/public-conan && ' +
+                            'conan remote add -f stellarstation https://api.bintray.com/conan/infostellarinc/stellarstation-conan &&' +
                             'conan remote add -f inexorgame https://api.bintray.com/conan/inexorgame/inexor-conan && ' +
                             'conan install . -s compiler=gcc -s compiler.libcxx=libstdc++ -s compiler.version=7')
             workingDir conanDir
@@ -84,4 +107,32 @@ afterEvaluate {
     tasks.generateProto.doLast {
         delete 'build/conan/src/google'
     }
+
+    def conanDir = 'build/conan'
+    task createPackage(type: Exec) {
+        dependsOn generateProto
+        executable 'bash'
+        args '-c', condaCommand(
+                'conan create . -s compiler=gcc -s compiler.libcxx=libstdc++ -s compiler.version=7 stellarstation/testing')
+        workingDir conanDir
+    }
+
+    task uploadPackage {
+        dependsOn createPackage
+
+        doLast {
+            exec {
+                def user = rootProject.property('bintray.user')
+                def key = rootProject.property('bintray.key')
+
+                executable 'bash'
+                args '-c', condaCommand(
+                        "conan user -p $key -r stellarstation $user && " +
+                                "conan upload stellarstation-api/$version@stellarstation/testing --all -r=stellarstation")
+                workingDir = conanDir
+            }
+        }
+    }
+
+    uploadPackage.onlyIf { !version.endsWith('SNAPSHOT') }
 }

--- a/stubs/cpp/build.gradle
+++ b/stubs/cpp/build.gradle
@@ -122,13 +122,11 @@ afterEvaluate {
 
         doLast {
             exec {
-                def user = rootProject.property('bintray.user')
-                def key = rootProject.property('bintray.key')
-
                 executable 'bash'
+                environment 'CONAN_LOGIN_USERNAME_STELLARSTATION', rootProject.property('bintray.user')
+                environment 'CONAN_PASSWORD_STELLARSTATION', rootProject.property('bintray.key')
                 args '-c', condaCommand(
-                        "conan user -p $key -r stellarstation $user && " +
-                                "conan upload stellarstation-api/$version@$reference --all -r=stellarstation")
+                        "conan upload stellarstation-api/$version@$reference --all -r=stellarstation")
                 workingDir = conanDir
             }
         }

--- a/stubs/cpp/build.gradle
+++ b/stubs/cpp/build.gradle
@@ -53,8 +53,8 @@ protobuf {
 }
 
 task prepareConanfilePy {
-    inputs.property("version", version);
-    inputs.file("package/conanfile.py.tmpl")
+    inputs.property('version', version);
+    inputs.file('package/conanfile.py.tmpl')
     outputs.file("$buildDir/generated/scripts/conanfile.py")
 
     doFirst {
@@ -64,7 +64,6 @@ task prepareConanfilePy {
         mkdir outDir
         def out = file("${outDir}/conanfile.py")
         out.text = filled
-        out.executable = true
     }
 }
 
@@ -109,7 +108,7 @@ afterEvaluate {
     }
 
     def conanDir = 'build/conan'
-    def reference = 'stellarstation/testing'
+    def reference = 'stellarstation/stable'
     task createPackage(type: Exec) {
         dependsOn generateProto
         executable 'bash'

--- a/stubs/cpp/build.gradle
+++ b/stubs/cpp/build.gradle
@@ -109,11 +109,12 @@ afterEvaluate {
     }
 
     def conanDir = 'build/conan'
+    def reference = 'stellarstation/testing'
     task createPackage(type: Exec) {
         dependsOn generateProto
         executable 'bash'
         args '-c', condaCommand(
-                'conan create . -s compiler=gcc -s compiler.libcxx=libstdc++ -s compiler.version=7 stellarstation/testing')
+                "conan create . -s compiler=gcc -s compiler.libcxx=libstdc++ -s compiler.version=7 $reference")
         workingDir conanDir
     }
 
@@ -128,7 +129,7 @@ afterEvaluate {
                 executable 'bash'
                 args '-c', condaCommand(
                         "conan user -p $key -r stellarstation $user && " +
-                                "conan upload stellarstation-api/$version@stellarstation/testing --all -r=stellarstation")
+                                "conan upload stellarstation-api/$version@$reference --all -r=stellarstation")
                 workingDir = conanDir
             }
         }

--- a/stubs/cpp/package/conanfile.py.tmpl
+++ b/stubs/cpp/package/conanfile.py.tmpl
@@ -3,7 +3,7 @@ from conans import ConanFile, CMake
 
 class StellarstationApiConan(ConanFile):
     name = "stellarstation-api"
-    version = "0.0.8"
+    version = "|API_VERSION|"
     license = "Apache-2.0"
     url = "https://github.com/infostellarinc/stellarstation-api"
     description = "C++ gRPC stubs for conneting to the StellarStation API."

--- a/stubs/cpp/package/src/CMakeLists.txt
+++ b/stubs/cpp/package/src/CMakeLists.txt
@@ -5,4 +5,5 @@ include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)
 conan_basic_setup()
 
 include_directories(.)
-add_library(stellarstation stellarstation/api/v1/stellarstation.grpc.pb.cc stellarstation/api/v1/stellarstation.pb.cc)
+file(GLOB_RECURSE SOURCES RELATIVE ${CMAKE_SOURCE_DIR} "stellarstation/api/v1/*.cc")
+add_library(stellarstation ${SOURCES})

--- a/stubs/python/build.gradle
+++ b/stubs/python/build.gradle
@@ -61,7 +61,7 @@ task fillRunProtocScript {
 task prepareSetupPy {
     inputs.property("version", version);
     inputs.file("src/misc/python/setup.py.tmpl")
-    outputs.file("$buildDir/generated/scripts")
+    outputs.file("$buildDir/generated/scripts/setup.py")
 
     doFirst {
         def template = file('src/misc/python/setup.py.tmpl').text


### PR DESCRIPTION
Note: cmake is required on the host machine to do package creation and publishing.

1) Bintray user and API key are read from gradle properties
2) CMakeLists use glob to find source files.
3) Only publish non-snapshot versions
4) Version number is automatically populated into conanfile.py via templating

