### PR TITLE
Update publishing for nodejs

### DIFF
--- a/stubs/nodejs/.npmrc
+++ b/stubs/nodejs/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/stubs/nodejs/build.gradle
+++ b/stubs/nodejs/build.gradle
@@ -96,13 +96,19 @@ task installProtocPlugins(type: NpmTask) {
 
     outputs.dir 'node_modules/grpc-tools'
     outputs.dir 'node_modules/grpc_tools_node_protoc_ts'
-    environment = ["NPM_TOKEN": rootProject.property('npm.key')]
+
+    // This is added in case the build/web directory contains our project-level .npmrc (this can
+    // happen if a publication was run before). Since the .npmrc references NPM_TOKEN, we need to
+    // define it here. It's safe for the variable to be null.
+    environment = ['NPM_TOKEN': rootProject.findProperty('npm.key')]
 
     finalizedBy addResolvedPluginScript
 }
 
 task generatePackageJson {
-    inputs.property('version', version);
+    inputs.property 'version', version
+    inputs.property 'grpc-tools-version', GRPC_TOOLS_VERSION
+    inputs.property 'grpc-tools-ts-version', GRPC_TOOLS_TS_VERSION
     inputs.files 'package-template.json'
     outputs.file 'build/web/package.json'
 
@@ -125,7 +131,7 @@ task publish(type: NpmTask) {
 
     dependsOn 'build'
     args = ['publish', '--access=public']
-    environment = ["NPM_TOKEN": rootProject.property('npm.key')]
+    environment = ['NPM_TOKEN': rootProject.findProperty('npm.key')]
     workingDir = file('build/web')
     onlyIf { !version.endsWith('SNAPSHOT') }
 }

--- a/stubs/nodejs/build.gradle
+++ b/stubs/nodejs/build.gradle
@@ -96,11 +96,13 @@ task installProtocPlugins(type: NpmTask) {
 
     outputs.dir 'node_modules/grpc-tools'
     outputs.dir 'node_modules/grpc_tools_node_protoc_ts'
+    environment = ["NPM_TOKEN": rootProject.property('npm.key')]
 
     finalizedBy addResolvedPluginScript
 }
 
 task generatePackageJson {
+    inputs.property('version', version);
     inputs.files 'package-template.json'
     outputs.file 'build/web/package.json'
 
@@ -108,14 +110,24 @@ task generatePackageJson {
         def packageTemplate = file('package-template.json').text
         packageTemplate = packageTemplate.replace('|GRPC_VERSION|', GRPC_VERSION)
                 .replace('|GOOGLE_PROTOBUF_VERSION|', GOOGLE_PROTOBUF_VERSION)
+                .replace('|API_VERSION|', version.toString())
         file('build/web/package.json').text = packageTemplate
     }
 }
 
 task publish(type: NpmTask) {
+    doFirst {
+        copy {
+            from ".npmrc"
+            into "build/web"
+        }
+    }
+
     dependsOn 'build'
     args = ['publish', '--access=public']
+    environment = ["NPM_TOKEN": rootProject.property('npm.key')]
     workingDir = file('build/web')
+    onlyIf { !version.endsWith('SNAPSHOT') }
 }
 
 node {

--- a/stubs/nodejs/package-template.json
+++ b/stubs/nodejs/package-template.json
@@ -1,6 +1,6 @@
 {
   "name": "@infostellarinc/stellarstation-api",
-  "version": "0.0.8-alpha.1",
+  "version": "|API_VERSION|",
   "description": "NodeJS gRPC stubs for accessing the StellarStation API.",
   "repository": "infostellarinc/stellarstation-api",
   "author": "The StellarStation Team",


### PR DESCRIPTION
The change is small but it has a couple of quirks.

1) The environment for installing protoc plugins needed updated in the case that the .npmrc file happens to exist in the build/web directory.

2) I use findProperty to prevent failure if the property doesn't exist
