### PR TITLE
Publish all stubs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,10 @@ allprojects {
         def bintrayUser = findProperty('bintray.user')
         def bintrayKey = findProperty('bintray.key')
 
+        // Skip the task if this is a snapshot.
+        tasks.bintrayUpload.onlyIf { !version.endsWith('SNAPSHOT') }
+        rootProject.tasks.bintrayPublish.onlyIf { !version.endsWith('SNAPSHOT') }
+
         afterEvaluate {
             bintray {
                 publish = true
@@ -121,4 +125,11 @@ task installPythonTools(type: Exec) {
     dependsOn 'pythonSetup'
     executable 'bash'
     args '-c', condaCommand('pip install conan grpcio-tools twine')
+}
+
+task publishStubs {
+    dependsOn ':api:bintrayUpload'
+    dependsOn ':stubs:cpp:uploadPackage'
+    dependsOn ':stubs:nodejs:publish'
+    dependsOn ':stubs:python:uploadPythonPackage'
 }


### PR DESCRIPTION
Not sure if the 'onlyIf' checks are the best approach here since the behavior of 'publish' might be a bit mysterious.

One issue that people might run into is if the publishing partially succeeds - in that case re-running might be problematic if the repo doesn't allow skipping identical versions (PyPi does allow skipping if the version number is the same).