### PR TITLE
Modified go_package so that Go code can fetch StellarStation package …

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
@@ -21,7 +21,7 @@ import "stellarstation/api/v1/radio/radio.proto";
 
 package stellarstation.api.v1.groundstation;
 
-option go_package = "groundstation";
+option go_package = "github.com/infostellarinc/go-stellarstation/api/v1/groundstation";
 
 option java_multiple_files = true;
 option java_outer_classname = "GroundStationProto";

--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -18,7 +18,7 @@ syntax = "proto3";
 
 package stellarstation.api.v1.radio;
 
-option go_package = "radio";
+option go_package = "github.com/infostellarinc/go-stellarstation/api/v1/radio";
 
 option java_multiple_files = true;
 option java_outer_classname = "RadioProto";

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -20,7 +20,7 @@ import "google/protobuf/timestamp.proto";
 
 package stellarstation.api.v1;
 
-option go_package = "stellarstation";
+option go_package = "github.com/infostellarinc/go-stellarstation/api/v1";
 
 option java_multiple_files = true;
 option java_outer_classname = "StellarstationProto";


### PR DESCRIPTION
…from go-stellarstation.

Currently, protoc generates import path of groundstation.proto files with relative path to radio package (`import radio "stellarstation/api/v1/radio"`) since go_package doesn't contain full path from `github.com/infostellarinc...`. In order to build property with go-stellarstation, those import path need to be complete.
