### PR TITLE
Add window id to the response of AddUnavailabilityWindow

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
@@ -174,7 +174,8 @@ message AddUnavailabilityWindowRequest {
 
 // A response from the 'AddUnavailabilityWindow' method.
 message AddUnavailabilityWindowResponse {
-  // Currently no payload in the response.
+  // ID of the window.
+  string window_id = 1;
 }
 
 // A request for deleting an existing unavailability window for the specified ground station.

--- a/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
@@ -174,7 +174,7 @@ message AddUnavailabilityWindowRequest {
 
 // A response from the 'AddUnavailabilityWindow' method.
 message AddUnavailabilityWindowResponse {
-  // ID of the window.
+  // ID of the new window.
   string window_id = 1;
 }
 


### PR DESCRIPTION
This was missed due to an oversight (our internal API doesn't actually return the ID for some reason).