### PR TITLE
Commit vendor directory for golang versions which don't support go modules

### DIFF
--- a/cloudbuild/snapshot-publish.yaml
+++ b/cloudbuild/snapshot-publish.yaml
@@ -26,4 +26,4 @@ steps:
     ./gradlew :api:artifactoryPublish :stubs:golang:gitPublishPush -Pbintray.user=$$BINTRAY_USER -Pbintray.key=$$BINTRAY_KEY --stacktrace --no-daemon
   env: ['BINTRAY_USER=istellar-admin']
   secretEnv: ['BINTRAY_KEY']
-  timeout: 600s
+  timeout: 60m

--- a/stubs/golang/build.gradle.kts
+++ b/stubs/golang/build.gradle.kts
@@ -66,7 +66,7 @@ gitPublish {
         from("build/generated/proto/main/github.com/infostellarinc/go-stellarstation/api") {
             into("api")
         }
-        from"build/generated/proto/main/github.com/infostellarinc/go-stellarstation/vendor") {
+        from("build/generated/proto/main/github.com/infostellarinc/go-stellarstation/vendor") {
             into("vendor")
         }
     }

--- a/stubs/golang/build.gradle.kts
+++ b/stubs/golang/build.gradle.kts
@@ -58,12 +58,17 @@ gitPublish {
     preserve {
         include("**")
         exclude("api")
+        exclude("vendor")
     }
 
     // what to publish, this is a standard CopySpec
     contents {
-        from("build/generated/proto/main/github.com/infostellarinc/go-stellarstation/api")
-        into("api")
+        from("build/generated/proto/main/github.com/infostellarinc/go-stellarstation/api") {
+            into("api")
+        }
+        from"build/generated/proto/main/github.com/infostellarinc/go-stellarstation/vendor") {
+            into("vendor")
+        }
     }
 
     commitMessage.set("Refresh API stubs.")


### PR DESCRIPTION
... and extend build timeout because of the increase of dependencies.