### PR TITLE
Restore grpc_python generation that was lost in kotlin migration.

### DIFF
--- a/stubs/python/build.gradle.kts
+++ b/stubs/python/build.gradle.kts
@@ -43,6 +43,10 @@ protobuf {
         register("python") {
             outputDir.set(file(packageDir))
         }
+
+        register("grpc_python") {
+            outputDir.set(file(packageDir))
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #99 