### PR TITLE
Add polarization to radio device configuration.

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -71,10 +71,10 @@ enum Polarization {
   ANY = 0;
 
   // Horizontal polarization.
-  H = 1;
+  HORIZONTAL = 1;
 
-  // Horizontal polarization.
-  V = 2;
+  // Vertical polarization.
+  VERTICAL = 2;
 
   // Left hand circular polarization.
   LHCP = 3;

--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -43,6 +43,9 @@ message RadioDeviceConfiguration {
   // The protocol used by this device when doing RF communication. If unset, the device is only
   // demodulating / modulating without applying any higher-level communication protocol.
   CommunicationProtocol protocol = 4;
+
+  // The polarization used by this radio device.
+  Polarization polarization = 5;
 }
 
 // A communication protocol used with a radio device. These must contain all the parameters
@@ -58,6 +61,27 @@ message CommunicationProtocol {
     // Bitstream framing settings.
     Bitstream bitstream = 3;
   }
+}
+
+// The type of polarization the antenna will use.
+enum Polarization {
+  // Any polarization can be used for communications.
+  ANY = 0;
+
+  // Horizontal polarization.
+  HORIZONTAL = 1;
+
+  // Horizontal polarization.
+  VERTICAL = 2;
+
+  // Left hand circular polarization.
+  LEFT_HAND_CIRCULAR = 3;
+
+  // Right hand circular polarization.
+  RIGHT_HAND_CIRCULAR = 4;
+
+  // Simultaneous left and right hand circular polarization.
+  SIMULTANEOUS_LEFT_HAND_RIGHT_HAND_CIRCULAR = 5;
 }
 
 // CCSDS-specific convolutional coding parameters.

--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -64,24 +64,23 @@ message CommunicationProtocol {
 }
 
 // The type of polarization the antenna will use.
+//
+// https://en.wikipedia.org/wiki/Antenna_(radio)#Polarization
 enum Polarization {
   // Any polarization can be used for communications.
   ANY = 0;
 
   // Horizontal polarization.
-  HORIZONTAL = 1;
+  H = 1;
 
   // Horizontal polarization.
-  VERTICAL = 2;
+  V = 2;
 
   // Left hand circular polarization.
-  LEFT_HAND_CIRCULAR = 3;
+  LHCP = 3;
 
   // Right hand circular polarization.
-  RIGHT_HAND_CIRCULAR = 4;
-
-  // Simultaneous left and right hand circular polarization.
-  SIMULTANEOUS_LEFT_HAND_RIGHT_HAND_CIRCULAR = 5;
+  RHCP = 4;
 }
 
 // CCSDS-specific convolutional coding parameters.


### PR DESCRIPTION
I was thinking about using common abbreviations like `LHCP` instead of `LEFT_HAND_CIRCULAR` but it might not be immediately obvious to some people.

@reiinakano please let me know if there are any common polarization I've missed.