### PR TITLE
Update to curiostack 183 and add a release publishing cloudbuild config.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -23,8 +23,8 @@ apply plugin: 'org.curioswitch.gradle-grpc-api-plugin'
 
 archivesBaseName = 'stellarstation-api'
 
-sourceCompatibility = '1.6'
-targetCompatibility = '1.6'
+sourceCompatibility = '1.7'
+targetCompatibility = '1.7'
 
 publishing {
     publications {

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@
  */
 
 plugins {
-    id 'com.github.blindpirate.gogradle' version '0.10' apply false
     id 'org.ajoberstar.git-publish' version '2.0.0-rc.2' apply false
     id 'org.curioswitch.gradle-curiostack-plugin'
 }

--- a/cloudbuild/release-publish.yaml
+++ b/cloudbuild/release-publish.yaml
@@ -1,0 +1,32 @@
+secrets:
+  - kmsKeyName: projects/infostellar-cluster/locations/us-central1/keyRings/cloudbuild/cryptoKeys/deploy-stubs
+    secretEnv:
+      BINTRAY_KEY: CiQAo3bGoZ8oqTtDBX7G5hReUiSymLSobSDvpa3w9qq7/iTnrf8SUQD6f46OKS7QQjJ0JRTfwcIlgcfWN89NbmlLMtzGP582qvCcDhh57vd1JR/lr/SZ8HolfzEAZP6k/SdfEZ+oF/u7/CiCWOUzRlgLWFg1Mqm8PA==
+      NPM_KEY: CiQAo3bGoRJ721LzjFjReYDlNaQnml+KdXtUFlhNcxjTLu0EI/ISTQD6f46ObEDBR7Sfp2ghkjd2C12bHgjeple0Yt2DctBcumNYT0Ic7s0po4GSFEEX1QVKkFALZZrkCtAv/4prRoZmZlRdm7Ns1Otjvgq4
+      PYPI_KEY: CiQAo3bGoYxDEMHcyJkPIdmcvbfRIbet09HVwIPrxhAGKP3UHGESNQD6f46OLClPEFS8FpMcW+AXpBrxGkJEkY1dGj3iziGQVvGbULd4Mh3/vXQEPU14d2MC/NaC
+steps:
+- id: publish-release
+  waitFor:
+    - '-'
+  name: curiostack/java-cloud-builder
+  entrypoint: ./gradlew
+  args:
+    - -Ppypi.user=istellar-sysadmin
+    - -Ppypi.password=$$PYPI_KEY
+    - -Pbintray.user=istellar-admin
+    - -Pbintray.key=$$BINTRAY_KEY
+    - -Pnpm.key=$$NPM_KEY
+    - -Pcuriostack.release=true
+    - --stacktrace
+    - --no-daemon
+    - publishStubs
+  secretEnv:
+  - BINTRAY_KEY
+  - NPM_KEY
+  - PYPI_KEY
+  env:
+  - CI=true
+  - TAG_NAME=$TAG_NAME
+  - BRANCH_NAME=$BRANCH_NAME
+timeout: 60m
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-org.curioswitch.curiostack.version = 0.0.175.2
-version = 0.2.1-SNAPSHOT
+org.curioswitch.curiostack.version = 0.0.183
 
 org.gradle.jvmargs=-Xmx2048m

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -35,6 +35,23 @@ pluginManagement {
     }
 }
 
+buildscript {
+    repositories {
+        jcenter()
+        gradlePluginPortal()
+        maven {
+            url 'https://dl.bintray.com/curioswitch/curiostack'
+        }
+        maven {
+            url 'https://palantir.bintray.com/releases'
+        }
+        mavenLocal()
+    }
+    dependencies {
+        classpath "org.curioswitch.curiostack:gradle-curiostack-plugin:${getProperty('org.curioswitch.curiostack.version')}"
+    }
+}
+
 include ':api'
 include ':examples:fakeserver'
 include ':examples:java:printing-client'

--- a/stubs/cpp/build.gradle.kts
+++ b/stubs/cpp/build.gradle.kts
@@ -15,8 +15,8 @@
  */
 
 plugins {
+    java
     id("org.curioswitch.gradle-protobuf-plugin")
-    id("io.spring.dependency-management")
 }
 
 repositories {
@@ -143,5 +143,13 @@ tasks {
                 org.curioswitch.gradle.conda.exec.CondaExecUtil.condaExec(this, project)
             }
         }
+    }
+
+    named("compileJava") {
+        enabled = false
+    }
+
+    named("compileTestJava") {
+        enabled = false
     }
 }

--- a/stubs/docs/build.gradle.kts
+++ b/stubs/docs/build.gradle.kts
@@ -15,9 +15,9 @@
  */
 
 plugins {
+    java
     id("org.curioswitch.gradle-golang-plugin")
     id("org.curioswitch.gradle-protobuf-plugin")
-    id("io.spring.dependency-management")
 }
 
 repositories {
@@ -72,4 +72,12 @@ tasks {
     named("goTest").configure({
         enabled = false
     })
+
+    named("compileJava") {
+        enabled = false
+    }
+
+    named("compileTestJava") {
+        enabled = false
+    }
 }

--- a/stubs/golang/build.gradle.kts
+++ b/stubs/golang/build.gradle.kts
@@ -15,9 +15,9 @@
  */
 
 plugins {
+    java
     id("org.curioswitch.gradle-golang-plugin")
     id("org.curioswitch.gradle-protobuf-plugin")
-    id("io.spring.dependency-management")
     id("org.ajoberstar.git-publish")
 }
 
@@ -217,4 +217,12 @@ tasks {
     named("goTest").configure({
         enabled = false
     })
+
+    named("compileJava") {
+        enabled = false
+    }
+
+    named("compileTestJava") {
+        enabled = false
+    }
 }

--- a/stubs/nodejs/build.gradle.kts
+++ b/stubs/nodejs/build.gradle.kts
@@ -15,8 +15,8 @@
  */
 
 plugins {
+    java
     id("org.curioswitch.gradle-protobuf-plugin")
-    id("io.spring.dependency-management")
     id("com.moowork.node") version "1.2.0"
 }
 
@@ -131,6 +131,14 @@ tasks {
 
     named("clean").configure {
         delete(file("node_modules"))
+    }
+
+    named("compileJava") {
+        enabled = false
+    }
+
+    named("compileTestJava") {
+        enabled = false
     }
 }
 

--- a/stubs/python/build.gradle.kts
+++ b/stubs/python/build.gradle.kts
@@ -16,8 +16,8 @@
 
 
 plugins {
+    java
     id("org.curioswitch.gradle-protobuf-plugin")
-    id("io.spring.dependency-management")
 }
 
 val packageDir = file("build/publications/python").getAbsolutePath()
@@ -184,5 +184,13 @@ tasks {
 
     named("assemble").configure {
         dependsOn(buildPythonPackage)
+    }
+
+    named("compileJava") {
+        enabled = false
+    }
+
+    named("compileTestJava") {
+        enabled = false
     }
 }

--- a/stubs/python/src/misc/run_protoc.sh.tmpl
+++ b/stubs/python/src/misc/run_protoc.sh.tmpl
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Filter out java out parameter
+args=("$@")
+for ((i=0; i<"${#args[@]}"; ++i)); do
+    case ${args[i]} in
+        --java_out*) unset args[i]; break;;
+    esac
+done
+
 . |CONDA_PROFILE_PATH|
 conda activate > /dev/null
-python -m grpc_tools.protoc "$@"
+python -m grpc_tools.protoc "${args[@]}"


### PR DESCRIPTION
- Updates java stubs min version to 1.7, same as protobuf
- Newer curiostack uses Gradle's bom instead of spring dependencies, which only works on java projects. So adds java plugin even to non-java stubs
