### PR TITLE
Fix processing of go.mod file

### DIFF
--- a/stubs/golang/build.gradle.kts
+++ b/stubs/golang/build.gradle.kts
@@ -131,7 +131,7 @@ tasks {
 
         dependsOn(generateProto, installMockGen, runModVendoring)
 
-        val goModLines = File("${System.getProperty("user.dir")}/stubs/golang/go.mod").readLines()
+        val goModLines = file("go.mod").readLines()
         var foundRequire = false
 
         for (line in goModLines) {

--- a/stubs/golang/go.mod
+++ b/stubs/golang/go.mod
@@ -1,3 +1,17 @@
+// Copyright 2018 Infostellar, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 module github.com/infostellarinc/go-stellarstation
 
 go 1.12
@@ -8,20 +22,4 @@ require (
 	github.com/square/goprotowrap v0.0.0-20190116012208-bb93590db2db // indirect
 	golang.org/x/net v0.0.0-20190424112056-4829fb13d2c6
 	google.golang.org/grpc v1.20.1
-<!--
-  ~ Copyright 2018 Infostellar, Inc.
-  ~
-  ~ Licensed under the Apache License, Version 2.0 (the "License");
-  ~ you may not use this file except in compliance with the License.
-  ~ You may obtain a copy of the License at
-  ~
-  ~    http://www.apache.org/licenses/LICENSE-2.0
-  ~
-  ~ Unless required by applicable law or agreed to in writing, software
-  ~ distributed under the License is distributed on an "AS IS" BASIS,
-  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  ~ See the License for the specific language governing permissions and
-  ~ limitations under the License.
-  -->
-
 )


### PR DESCRIPTION
The build was failing because we have custom parsing code for go.mod that failed when it hit the license that was placed in the middle of the file. Moved this to the top and used normal go.mod comments instead.

Also stop using 'user.dir' property. It varies depending on where gradle is run from so fails if you directly run this project build file in the gradle UI. I think it is normal to just give the relative path from the build file.