### PR TITLE
Fix creation of conan package

### DIFF
--- a/stubs/cpp/build.gradle.kts
+++ b/stubs/cpp/build.gradle.kts
@@ -85,11 +85,6 @@ tasks {
                 into(conanDir)
             }
 
-            copy {
-                from("package/src")
-                into("$conanDir/src")
-            }
-
             exec {
                 commandLine("conan remote add -f bincrafters https://api.bintray.com/conan/bincrafters/public-conan && " +
                         "conan remote add -f stellarstation https://api.bintray.com/conan/infostellarinc/stellarstation-conan &&" +
@@ -119,6 +114,11 @@ tasks {
         dependsOn(generateProto)
 
         doFirst {
+            copy {
+                from("package/src")
+                into("$conanDir/src")
+            }
+
             exec {
                 commandLine("conan create . -s compiler=gcc -s compiler.libcxx=libstdc++ -s compiler.version=7 $reference")
                 workingDir(conanDir)


### PR DESCRIPTION
The package creation runs after generation of protos but seems to fail complaining a file isn't found.

The proto generation writes directly into build/conan/src, but it clears the contents of that directory first. This breaks the build because we need one of the existing files in that directory. Fix is to copy the file we need after the protos are generated instead of before.