### PR TITLE
Fix and re-enable C++ stub publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,8 +120,7 @@ allprojects {
 task publishStubs {
     description 'Publishes API stubs (only works for non-snapshot versions)'
     dependsOn ':api:bintrayUpload'
-    // Disabled temporarily until we investigate why publishing failed.
-    //dependsOn ':stubs:cpp:uploadPackage'
+    dependsOn ':stubs:cpp:uploadPackage'
     dependsOn ':stubs:golang:gitPublishCommit'
     // dependsOn ':stubs:nodejs:publish'
     dependsOn ':stubs:python:uploadPythonPackage'

--- a/stubs/cpp/build.gradle.kts
+++ b/stubs/cpp/build.gradle.kts
@@ -137,7 +137,10 @@ tasks {
 
         doFirst {
             exec {
-                commandLine("conan upload stellarstation-api/$version@$reference --all -r=stellarstation")
+                environment(Pair("CONAN_LOGIN_USERNAME", findProperty("bintray.user")))
+                environment(Pair("CONAN_PASSWORD", findProperty("bintray.key")))
+                commandLine("conan user --remote stellarstation --password && " +
+                        "conan upload stellarstation-api/$version@$reference --all -r=stellarstation")
                 workingDir(conanDir)
 
                 org.curioswitch.gradle.conda.exec.CondaExecUtil.condaExec(this, project)


### PR DESCRIPTION
I tested this by running cloud-build-local and could see the upload working correctly. I guess this never worked from the continuous build environment in the past.