### PR TITLE
Update to JDK 12

### DIFF
--- a/gradle/get-jdk.sh
+++ b/gradle/get-jdk.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+if [ -z "$CI" ]; then
+
+  # OS specific support (must be 'true' or 'false').
+  windows=false
+  darwin=false
+  linux=false
+  case "`uname`" in
+    MSYS* )
+      windows=true
+      ;;
+    CYGWIN* )
+      windows=true
+      ;;
+    Darwin* )
+      darwin=true
+      ;;
+    MINGW* )
+      windows=true
+      ;;
+    Linux* )
+      linux=true
+      ;;
+  esac
+
+  GRADLE_HOME="${GRADLE_USER_HOME:-${HOME}/.gradle}"
+  OPENJDK_DIR="$GRADLE_HOME/curiostack/openjdk"
+
+  export JAVA_HOME="$OPENJDK_DIR/jdk-12.0.1"
+  if "$darwin" = "true"; then
+    export JAVA_HOME="$JAVA_HOME.jdk/Contents/Home"
+  fi
+
+  if "$linux" = "true"; then
+    SRC="https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz"
+    DEST="$OPENJDK_DIR/openjdk-12.0.1_linux-x64_bin.tar.gz"
+  fi
+
+  if "$darwin" = "true"; then
+    SRC="https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_osx-x64_bin.tar.gz"
+    DEST="$OPENJDK_DIR/openjdk-12.0.1_osx-x64_bin.tar.gz"
+  fi
+
+  if "$windows" = "true"; then
+    SRC="https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_windows-x64_bin.zip"
+    DEST="$OPENJDK_DIR/openjdk-12.0.1_windows-x64_bin.zip"
+  fi
+
+  if [ ! -d "$JAVA_HOME" ]; then
+    mkdir -p "$OPENJDK_DIR"
+
+    echo "Downloading OpenJDK"
+    curl "$SRC" -o "$DEST"
+
+    cd "$OPENJDK_DIR"
+
+    if "$windows" = "true"; then
+      unzip "$DEST"
+    else
+      tar -xf "$DEST"
+    fi
+  fi
+
+fi

--- a/gradlew
+++ b/gradlew
@@ -1,5 +1,23 @@
 #!/usr/bin/env sh
 
+#
+# Copyright 2015 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+. gradle/get-jdk.sh
+
 ##############################################################################
 ##
 ##  Gradle start up script for UN*X
@@ -28,7 +46,7 @@ APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
 # Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
-DEFAULT_JVM_OPTS='"-Xmx64m"'
+DEFAULT_JVM_OPTS='"-Xmx64m" "-Xms64m"'
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.
 MAX_FD="maximum"


### PR DESCRIPTION
Also add a wrapper script for downloading the latest JDK. This will ensure that we no longer need to depend on the JDK already installed on the dev machine.