### PR TITLE
Use AdoptOpenJDK binaries which shouldn't go away and fix first downl…

### DIFF
--- a/gradle/get-jdk.sh
+++ b/gradle/get-jdk.sh
@@ -7,9 +7,6 @@ if [ -z "$CI" ]; then
   darwin=false
   linux=false
   case "`uname`" in
-    MSYS* )
-      windows=true
-      ;;
     CYGWIN* )
       windows=true
       ;;
@@ -19,46 +16,51 @@ if [ -z "$CI" ]; then
     MINGW* )
       windows=true
       ;;
+    MSYS* )
+      windows=true
+      ;;
     Linux* )
       linux=true
       ;;
   esac
 
   GRADLE_HOME="${GRADLE_USER_HOME:-${HOME}/.gradle}"
+
+  if [ ! -z "$USERPROFILE" ]; then
+    # msys
+    USERPROFILE_CYG=$(cygpath $USERPROFILE)
+    GRADLE_HOME="${USERPROFILE_CYG}/.gradle"
+  fi
+
   OPENJDK_DIR="$GRADLE_HOME/curiostack/openjdk"
 
-  export JAVA_HOME="$OPENJDK_DIR/jdk-12.0.1"
-  if "$darwin" = "true"; then
-    export JAVA_HOME="$JAVA_HOME.jdk/Contents/Home"
-  fi
+  export JAVA_HOME="$OPENJDK_DIR/jdk-12.0.1+12"
 
   if "$linux" = "true"; then
-    SRC="https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_linux-x64_bin.tar.gz"
-    DEST="$OPENJDK_DIR/openjdk-12.0.1_linux-x64_bin.tar.gz"
+    SRC="https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12/OpenJDK12U-jdk_x64_linux_hotspot_12.0.1_12.tar.gz"
+    DEST="$OPENJDK_DIR/OpenJDK12U-jdk_x64_linux_hotspot_12.0.1_12.tar.gz"
   fi
 
   if "$darwin" = "true"; then
-    SRC="https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_osx-x64_bin.tar.gz"
-    DEST="$OPENJDK_DIR/openjdk-12.0.1_osx-x64_bin.tar.gz"
+    SRC="https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12/OpenJDK12U-jdk_x64_mac_hotspot_12.0.1_12.tar.gz"
+    DEST="$OPENJDK_DIR/OpenJDK12U-jdk_x64_mac_hotspot_12.0.1_12.tar.gz"
   fi
 
   if "$windows" = "true"; then
-    SRC="https://download.java.net/java/GA/jdk12.0.1/69cfe15208a647278a19ef0990eea691/12/GPL/openjdk-12.0.1_windows-x64_bin.zip"
-    DEST="$OPENJDK_DIR/openjdk-12.0.1_windows-x64_bin.zip"
+    SRC="https://github.com/AdoptOpenJDK/openjdk12-binaries/releases/download/jdk-12.0.1%2B12/OpenJDK12U-jdk_x64_windows_hotspot_12.0.1_12.zip"
+    DEST="$OPENJDK_DIR/OpenJDK12U-jdk_x64_windows_hotspot_12.0.1_12.zip"
   fi
 
   if [ ! -d "$JAVA_HOME" ]; then
     mkdir -p "$OPENJDK_DIR"
 
     echo "Downloading OpenJDK"
-    curl "$SRC" -o "$DEST"
-
-    cd "$OPENJDK_DIR"
+    curl -L "$SRC" -o "$DEST"
 
     if "$windows" = "true"; then
-      unzip "$DEST"
+      unzip "$DEST" -d "$OPENJDK_DIR"
     else
-      tar -xf "$DEST"
+      tar -xf "$DEST" -C "$OPENJDK_DIR"
     fi
   fi
 


### PR DESCRIPTION
…oad doesn't work.

Oracle only distributes OpenJDK for one version now, so safer to use AdoptOpenJDK.

Also removes `cd` to finally fix the behavior when it's first run.