### PR TITLE
Get nodejs stub build working

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ task publishStubs {
     dependsOn ':api:bintrayUpload'
     dependsOn ':stubs:cpp:uploadPackage'
     dependsOn ':stubs:golang:gitPublishCommit'
-    // dependsOn ':stubs:nodejs:publish'
+    dependsOn ':stubs:nodejs:publish'
     dependsOn ':stubs:python:uploadPythonPackage'
 }
 

--- a/stubs/nodejs/build.gradle.kts
+++ b/stubs/nodejs/build.gradle.kts
@@ -17,13 +17,13 @@
 plugins {
     java
     id("org.curioswitch.gradle-protobuf-plugin")
-    id("com.moowork.node") version "1.2.0"
+    id("com.moowork.node") version "1.3.1"
 }
 
-val GRPC_TOOLS_VERSION = "1.6.6"
-val GRPC_TOOLS_TS_VERSION = "2.3.1"
+val GRPC_TOOLS_VERSION = "1.7.3"
+val GRPC_TOOLS_TS_VERSION = "2.5.1"
 
-val GRPC_VERSION = "1.16.0"
+val GRPC_VERSION = "1.21.1"
 val GOOGLE_PROTOBUF_VERSION = "3.6.1"
 
 repositories {
@@ -71,7 +71,9 @@ val isSnapshot = (version as String).endsWith("SNAPSHOT")
 tasks {
     val installProtocPlugins by registering(org.curioswitch.gradle.plugins.nodejs.tasks.NodeTask::class) {
         setCommand("npm")
-        args("install", "--no-save", "grpc-tools@${GRPC_TOOLS_VERSION}", "grpc_tools_node_protoc_ts@${GRPC_TOOLS_TS_VERSION}")
+        // unsafe-perm seems to be needed when this command is run as root (e.g. in cloud build).
+        args("install", "--unsafe-perm", "--no-save", "grpc-tools@${GRPC_TOOLS_VERSION}",
+                "grpc_tools_node_protoc_ts@${GRPC_TOOLS_TS_VERSION}")
 
         inputs.property("grpc-tools-version", GRPC_TOOLS_VERSION)
         inputs.property("grpc-tools-ts-version", GRPC_TOOLS_TS_VERSION)
@@ -143,7 +145,7 @@ tasks {
 }
 
 node {
-    version = "8.11.4"
-    yarnVersion = "1.9.4"
+    version = "10.16.0"
+    yarnVersion = "1.13.0"
     download = true
 }


### PR DESCRIPTION
There were a bunch of issues:

- to run npm install as root (which happens in the cloud build), --unsafe-perm seems to be required
- the proto generation step was wiping out the package.json (it clears the build/web directory). Added an explicit ordering constraint to fix this.
- the yarn publish command was failing with an error about the package being private. This seems to be coming from the package.json in the root of the repo. This is a bit mysterious but seems to be because the current working directory was being set to stubs/json instead of stubs/json/build/web (bug in curiostack plugin?). Adding a 'cwd' argument to the publish command line made it work (specifying just the path to the package.json didn't work because then yarn couldn't find the npmrc file).

The fix for the third issue is not very elegant. We're adding the 'cwd' option but that assumes yarn rather than npm is doing the publishing (don't think npm has a cwd option).
