### PR TITLE
Remove palantir repository from buildscript dependencies

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -28,9 +28,6 @@ pluginManagement {
         maven {
             url 'http://dl.bintray.com/curioswitch/curiostack'
         }
-        maven {
-            url 'http://palantir.bintray.com/releases'
-        }
         mavenLocal()
     }
 }
@@ -41,9 +38,6 @@ buildscript {
         gradlePluginPortal()
         maven {
             url 'https://dl.bintray.com/curioswitch/curiostack'
-        }
-        maven {
-            url 'https://palantir.bintray.com/releases'
         }
         mavenLocal()
     }


### PR DESCRIPTION
CurioStack 185 doesn't depend on Palantir baseline anymore.