### PR TITLE
Add uplink and downlink RadioDeviceConfiguration fields to ChannelSet.

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -300,6 +300,18 @@ message ChannelSet {
 
   // The name used to identify the channel set (for example, TT&C UHF).
   string name = 2;
+
+  // The center frequency used for uplink, in Hz. Set to 0 if the channel set is downlink only.
+  //
+  // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
+  //         incompatible ways in the future.
+  uint64 uplink_center_frequency_hz = 3;
+
+  // The center frequency used for downlink, in Hz. Set to 0 if the channel set is uplink only.
+  //
+  // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
+  //         incompatible ways in the future.
+  uint64 downlink_center_frequency_hz = 4;
 }
 
 // A pass during which a satellite can be communicated with from a given ground station.

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -308,7 +308,7 @@ message ChannelSet {
   //
   // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
   //         incompatible ways in the future.
-  radio.RadioDeviceConfiguration uplink = 3;
+  stellarstation.api.v1.radio.RadioDeviceConfiguration uplink = 3;
 
   // The radio device configuration used for downlinking.
   //
@@ -316,7 +316,7 @@ message ChannelSet {
   //
   // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
   //         incompatible ways in the future.
-  radio.RadioDeviceConfiguration downlink = 4;
+  stellarstation.api.v1.radio.RadioDeviceConfiguration downlink = 4;
 }
 
 // A pass during which a satellite can be communicated with from a given ground station.

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -17,6 +17,7 @@ syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
 import "stellarstation/api/v1/orbit/orbit.proto";
+import "stellarstation/api/v1/radio/radio.proto";
 import "stellarstation/api/v1/transport.proto";
 
 package stellarstation.api.v1;
@@ -301,17 +302,21 @@ message ChannelSet {
   // The name used to identify the channel set (for example, TT&C UHF).
   string name = 2;
 
-  // The center frequency used for uplink, in Hz. Set to 0 if the channel set is downlink only.
+  // The radio device configuration used for uplinking.
+  //
+  // Optional if downlink is set.
   //
   // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
   //         incompatible ways in the future.
-  uint64 uplink_center_frequency_hz = 3;
+  radio.RadioDeviceConfiguration uplink = 3;
 
-  // The center frequency used for downlink, in Hz. Set to 0 if the channel set is uplink only.
+  // The radio device configuration used for downlinking.
+  //
+  // Optional if uplink is set.
   //
   // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
   //         incompatible ways in the future.
-  uint64 downlink_center_frequency_hz = 4;
+  radio.RadioDeviceConfiguration downlink = 4;
 }
 
 // A pass during which a satellite can be communicated with from a given ground station.


### PR DESCRIPTION
I'm starting to think we should just add the full `RadioDeviceConfiguration` into the `ChannelSet`. @hoshir do you think it's valuable to expose the modulation / various radio device settings in this API as well, or would just the uplink/downlink frequency be adequate?