### PR TITLE
Small fixes

### DIFF
--- a/integration-tests/java/build.gradle
+++ b/integration-tests/java/build.gradle
@@ -49,6 +49,7 @@ task integrationTest(type: Test) {
 
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
+    outputs.upToDateWhen { false }
 }
 
 dependencies {

--- a/integration-tests/java/build.gradle
+++ b/integration-tests/java/build.gradle
@@ -49,7 +49,6 @@ task integrationTest(type: Test) {
 
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
-    outputs.upToDateWhen { false }
 }
 
 dependencies {

--- a/integration-tests/java/src/main/java/com/stellarstation/api/test/util/TimestampUtilities.java
+++ b/integration-tests/java/src/main/java/com/stellarstation/api/test/util/TimestampUtilities.java
@@ -28,6 +28,7 @@ public class TimestampUtilities {
         .build();
   }
 
+  @SuppressWarnings("ProtoTimestampGetSecondsGetNano")
   public static Instant toInstant(Timestamp timestamp) {
     return Instant.ofEpochSecond(Timestamps.toSeconds(timestamp), timestamp.getNanos());
   }


### PR DESCRIPTION
This PR makes two small changes:
1) Avoid integrationTest being skipped by Gradle due to UP-TO-DATE check.
2) Suppressed ProtoTimestampGetSecondsGetNano warning which appears when getSeconds isn't found around getNanos  method. In our code, getSeconds are called in Timestamps.toSeconds. So it is safe to suppress the warning.