### PR TITLE
Add channel set ID to send command request.

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -182,7 +182,7 @@ message SatelliteStreamRequest {
 
 // A request to send commands to a satellite.
 //
-// Next ID: 3
+// Next ID: 4
 message SendSatelliteCommandsRequest {
   // The command frames to send to the satellite. All commands will be transmitted in sequence
   // immediately, during which time telemetry will not be received. After all commands have been
@@ -190,6 +190,17 @@ message SendSatelliteCommandsRequest {
   // is 2MB. If a command larger than 2MB is received, the stream will be closed with a
   // `RESOURCE_EXHAUSTED` error.
   repeated bytes command = 2;
+
+  // The ID of the channel to be used when sending the command. Required if two uplink-capable
+  // plans are simultaneously executing. If not provided and only one plan is executing, the
+  // channel set will be automatically determined.
+  //
+  // If a channel set without an uplink component is provided or two uplink-capable plans are
+  // simultaneously executing and no ID is provided, the command will be ignored.
+  //
+  // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
+  //         incompatible ways in the future.
+  string channel_set_id = 3;
 }
 
 // A response from the `OpenSatelliteStream` method.

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -191,7 +191,7 @@ message SendSatelliteCommandsRequest {
   // `RESOURCE_EXHAUSTED` error.
   repeated bytes command = 2;
 
-  // The ID of the channel to be used when sending the command. Required if two uplink-capable
+  // The ID of the channel set to be used when sending the command. Required if two uplink-capable
   // plans are simultaneously executing. If not provided and only one plan is executing, the
   // channel set will be automatically determined.
   //


### PR DESCRIPTION
We need to allow defining which channel set to send commands using in some cases. 

If two plans that have uplink configurations are simultaneously executing, it's unclear which uplink configuration will be used. This allows a user to pick which channel set to use.