### PR TITLE
Control ground station hardware through API 

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/monitoring/monitoring.proto
+++ b/api/src/main/proto/stellarstation/api/v1/monitoring/monitoring.proto
@@ -34,6 +34,8 @@ option java_package = "com.stellarstation.api.v1.monitoring";
 //
 // A transmitter takes a bitstream and applies signal processing to create the final waveform sent
 // to a satellite.
+// TODO: Add parameters which describes whether modulation, idle pattern and IF sweep is enabled.
+// TODO: Add way to check whether parameter modification through API is supported.
 message TransmitterConfiguration {
   // The modulation type of the transmitter.
   radio.Modulation modulation = 1;

--- a/api/src/main/proto/stellarstation/api/v1/monitoring/monitoring.proto
+++ b/api/src/main/proto/stellarstation/api/v1/monitoring/monitoring.proto
@@ -34,8 +34,6 @@ option java_package = "com.stellarstation.api.v1.monitoring";
 //
 // A transmitter takes a bitstream and applies signal processing to create the final waveform sent
 // to a satellite.
-// TODO: Add parameters which describes whether modulation, idle pattern and IF sweep is enabled.
-// TODO: Add way to check whether parameter modification through API is supported.
 message TransmitterConfiguration {
   // The modulation type of the transmitter.
   radio.Modulation modulation = 1;

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -177,11 +177,11 @@ message SatelliteStreamRequest {
     // A request to send commands to the satellite.
     SendSatelliteCommandsRequest send_satellite_commands_request = 3;
 
-    // A request to control a ground station
+    // A request to modify a configuration of a ground station
     //
     // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
     //         incompatible ways in the future.
-    GroundStationControlRequest ground_station_control_request = 7;
+    GroundStationConfigurationRequest ground_station_configuration_request = 7;
   }
 
   // The `Framing` types to accept, for satellites that have been configured for multiple framings

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -178,6 +178,9 @@ message SatelliteStreamRequest {
     SendSatelliteCommandsRequest send_satellite_commands_request = 3;
 
     // A request to control a ground station
+    //
+    // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
+    //         incompatible ways in the future.
     GroundStationControlRequest ground_station_control_request = 7;
   }
 
@@ -201,6 +204,8 @@ message SendSatelliteCommandsRequest {
 // A request to modify configuration of ground station hardware.
 //
 // Next ID: 2
+// Status: ALPHA This API is under development and may not work correctly or be changed in backwards
+//         incompatible ways in the future.
 message GroundStationConfigurationRequest {
   // A request to modify transmitter configuration at a ground station.
   TransmitterConfigurationRequest transmitter_configuration_request = 1;
@@ -212,6 +217,8 @@ message GroundStationConfigurationRequest {
 // It isn't always supported to control them. If field isn't set, it's ignored.
 //
 // Next ID: 5
+// Status: ALPHA This API is under development and may not work correctly or be changed in backwards
+//         incompatible ways in the future.
 message TransmitterConfigurationRequest {
   //  Whether the carrier is enabled.
   google.protobuf.BoolValue enable_carrier = 1;

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -177,7 +177,7 @@ message SatelliteStreamRequest {
     // A request to send commands to the satellite.
     SendSatelliteCommandsRequest send_satellite_commands_request = 3;
 
-    // A request to modify a configuration of a ground station
+    // A request to modify a configuration of a ground station.
     //
     // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
     //         incompatible ways in the future.
@@ -213,23 +213,21 @@ message GroundStationConfigurationRequest {
 
 // A request to configure a transmitter at a ground station. Default state of these parameters
 // depends on hardware configuration at each ground station. Please check TransmitterConfiguration
-// in monitoring message. (Currently, some parameters are not supported.)
+// in monitoring message.
 // It isn't always supported to control them. If field isn't set, it's ignored.
 //
 // Next ID: 5
-// Status: ALPHA This API is under development and may not work correctly or be changed in backwards
-//         incompatible ways in the future.
 message TransmitterConfigurationRequest {
-  //  Whether the carrier is enabled.
+  // Enable carrier transmission.
   google.protobuf.BoolValue enable_carrier = 1;
 
-  // Enable IF modulation
+  // Enable IF modulation.
   google.protobuf.BoolValue enable_if_modulation = 2;
 
-  // Enable idle pattern transmission
+  // Enable idle pattern transmission.
   google.protobuf.BoolValue enable_idle_pattern = 3;
 
-  // Enable IF sweep
+  // Enable IF sweep.
   google.protobuf.BoolValue enable_if_sweep = 4;
 }
 

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -208,7 +208,7 @@ message GroundStationControlRequest {
 
 // A request to control a transmitter at a ground station. Default state of these parameters
 // depends on hardware configuration at each ground station. It isn't always supported to control
-// these parameters. If field isn't set, it's ignored.
+// them. If field isn't set, it's ignored.
 //
 // Next ID: 5
 message TransmitterControlRequest {

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -198,7 +198,7 @@ message SendSatelliteCommandsRequest {
   repeated bytes command = 2;
 }
 
-// A request to modify configuration of graoundstation hardware.
+// A request to modify configuration of ground station hardware.
 //
 // Next ID: 2
 message GroundStationConfigurationRequest {

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -16,6 +16,7 @@
 syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 import "stellarstation/api/v1/orbit/orbit.proto";
 import "stellarstation/api/v1/radio/radio.proto";
 import "stellarstation/api/v1/transport.proto";
@@ -144,6 +145,8 @@ service StellarStationService {
 //----------------------------------------------------------------------------------------------
 
 // Request for the `OpenSatelliteStream` method.
+//
+// Next ID: 8
 message SatelliteStreamRequest {
   // The ID of the satellite to open a stream with. The ID of a satellite can be found on the
   // StellarStation Console page for the satellite.
@@ -173,6 +176,9 @@ message SatelliteStreamRequest {
   oneof Request {
     // A request to send commands to the satellite.
     SendSatelliteCommandsRequest send_satellite_commands_request = 3;
+
+    // A request to control a ground station
+    GroundStationControlRequest ground_station_control_request = 7;
   }
 
   // The `Framing` types to accept, for satellites that have been configured for multiple framings
@@ -190,6 +196,33 @@ message SendSatelliteCommandsRequest {
   // is 2MB. If a command larger than 2MB is received, the stream will be closed with a
   // `RESOURCE_EXHAUSTED` error.
   repeated bytes command = 2;
+}
+
+// A request to control a ground station
+//
+// Next ID: 2
+message GroundStationControlRequest {
+  // A request to control a transmitter at a ground station.
+  TransmitterControlRequest transmitter_control_request = 1;
+}
+
+// A request to control a transmitter at a ground station. Default state of these parameters
+// depends on hardware configuration at each ground station. It isn't always supported to control
+// these parameters. If field isn't set, it's ignored.
+//
+// Next ID: 5
+message TransmitterControlRequest {
+  // Enable carrier transmission
+  google.protobuf.BoolValue enable_carrier = 1;
+
+  // Enable modulation
+  google.protobuf.BoolValue enable_modulation = 2;
+
+  // Enable idle pattern transmission
+  google.protobuf.BoolValue enable_idle_pattern = 3;
+
+  // Enable carrier sweep
+  google.protobuf.BoolValue enable_carrier_sweep = 4;
 }
 
 // A response from the `OpenSatelliteStream` method.

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -198,31 +198,32 @@ message SendSatelliteCommandsRequest {
   repeated bytes command = 2;
 }
 
-// A request to control a ground station
+// A request to modify configuration of graoundstation hardware.
 //
 // Next ID: 2
-message GroundStationControlRequest {
-  // A request to control a transmitter at a ground station.
-  TransmitterControlRequest transmitter_control_request = 1;
+message GroundStationConfigurationRequest {
+  // A request to modify transmitter configuration at a ground station.
+  TransmitterConfigurationRequest transmitter_configuration_request = 1;
 }
 
-// A request to control a transmitter at a ground station. Default state of these parameters
-// depends on hardware configuration at each ground station. It isn't always supported to control
-// them. If field isn't set, it's ignored.
+// A request to configure a transmitter at a ground station. Default state of these parameters
+// depends on hardware configuration at each ground station. Please check TransmitterConfiguration
+// in monitoring message. (Currently, some parameters are not supported.)
+// It isn't always supported to control them. If field isn't set, it's ignored.
 //
 // Next ID: 5
-message TransmitterControlRequest {
-  // Enable carrier transmission
+message TransmitterConfigurationRequest {
+  //  Whether the carrier is enabled.
   google.protobuf.BoolValue enable_carrier = 1;
 
-  // Enable modulation
-  google.protobuf.BoolValue enable_modulation = 2;
+  // Enable IF modulation
+  google.protobuf.BoolValue enable_if_modulation = 2;
 
   // Enable idle pattern transmission
   google.protobuf.BoolValue enable_idle_pattern = 3;
 
-  // Enable carrier sweep
-  google.protobuf.BoolValue enable_carrier_sweep = 4;
+  // Enable IF sweep
+  google.protobuf.BoolValue enable_if_sweep = 4;
 }
 
 // A response from the `OpenSatelliteStream` method.


### PR DESCRIPTION
This enable us to control ground station hardware through stream API during a plan.
Initially, this supports to control limited parameters on a transmitter related to carrier control.