### PR TITLE
Do not cancel plans on unavailability window creation.

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
@@ -42,9 +42,9 @@ option java_package = "com.stellarstation.api.v1.groundstation";
 service GroundStationService {
   // Adds a new unavailability window to the requested ground station.
   //
-  // Existing plans that overlap the unavailability window will be canceled. However, there
-  // are cases when the plan cannot be canceled. When this happens, the request will be closed
-  // with a 'FAILED_PRECONDITION' status.
+  // Existing plans that overlap the unavailability window will not be canceled and the request will
+  // be closed with a 'FAILED_PRECONDITION' status. In this case you will need to list any existing
+  // plans with ListPlans and then cancel the plans with CancelPlan.
   //
   // The request will be closed with an `INVALID_ARGUMENT` status if `ground_station_id`,
   // `start_time`, or `end_time` are missing, or 'end_time' is not after 'start_time'.


### PR DESCRIPTION
Although there are behavioural changes in the API, it is still code-compatible. Users who wish to block time on their ground stations much first explicitly cancel plans (after listing them) before placing a window.

There are times where a plan can't be cancelled (see cancellation policy), so a user will need to be able to handle that.