### PR TITLE
Deprecate pass reservation token.

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -368,7 +368,9 @@ message ChannelSet {
 // Next ID: 13
 message Pass {
   // A unique token for this pass that can be used for scheduling it.
-  string reservation_token = 1;
+  //
+  // Deprecated. Use ChannelSetToken.reservation_token.
+  string reservation_token = 1 [deprecated = true];
 
   // The time of Acquisition of Signal (AOS) between the ground station and satellite in this pass.
   google.protobuf.Timestamp aos_time = 2;


### PR DESCRIPTION
**Migration plan**
`reservation_token` is still being filled at the moment, however it is not clear which channel set will be used when reserving a pass with this token. Please use `ChannelSetToken.reservation_token` when reserving passes. 

The [CLI](https://github.com/infostellarinc/stellarcli) has already been showing per-channel-set reservation tokens for some time so no action is required for these users.