### PR TITLE
Deprecate downlink + uplink center frequency fields

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -402,11 +402,15 @@ message Pass {
 
   // The center frequency, in Hz, for downlinking in this pass. 0 if downlink is not available in
   // this pass.
-  uint64 downlink_center_frequency_hz = 9;
+  //
+  // Deprecated. Use ChannelSetToken.channel_set.downlink.center_frequency_hz.
+  uint64 downlink_center_frequency_hz = 9 [deprecated = true];
 
   // The center frequency, in Hz, for uplinking in this pass. 0 if uplink is not available in
   // this pass.
-  uint64 uplink_center_frequency_hz = 10;
+  //
+  // Deprecated. Use ChannelSetToken.channel_set.uplink.center_frequency_hz.
+  uint64 uplink_center_frequency_hz = 10 [deprecated = true];
 
   // A mapping of channel set to its unique reservation token.
   message ChannelSetToken {

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -403,13 +403,13 @@ message Pass {
   // The center frequency, in Hz, for downlinking in this pass. 0 if downlink is not available in
   // this pass.
   //
-  // Deprecated. Use ChannelSetToken.channel_set.downlink.center_frequency_hz.
+  // Deprecated. Use channel_set.downlink.center_frequency_hz.
   uint64 downlink_center_frequency_hz = 9 [deprecated = true];
 
   // The center frequency, in Hz, for uplinking in this pass. 0 if uplink is not available in
   // this pass.
   //
-  // Deprecated. Use ChannelSetToken.channel_set.uplink.center_frequency_hz.
+  // Deprecated. Use channel_set.uplink.center_frequency_hz.
   uint64 uplink_center_frequency_hz = 10 [deprecated = true];
 
   // A mapping of channel set to its unique reservation token.
@@ -536,10 +536,14 @@ message Plan {
 
   // The center frequency, in Hz, for downlinking in this plan. 0 if downlink is not available in
   // this plan.
+  //
+  // Deprecated. Use channel_set.downlink.center_frequency_hz.
   uint64 downlink_center_frequency_hz = 11;
 
   // The center frequency, in Hz, for uplinking in this plan. 0 if uplink is not available in
   // this plan.
+  //
+  // Deprecated. Use channel_set.uplink.center_frequency_hz.
   uint64 uplink_center_frequency_hz = 12;
 
   // Metadata for telemetry received during the pass. Only populated when the pass has completed

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -538,13 +538,13 @@ message Plan {
   // this plan.
   //
   // Deprecated. Use channel_set.downlink.center_frequency_hz.
-  uint64 downlink_center_frequency_hz = 11;
+  uint64 downlink_center_frequency_hz = 11 [deprecated = true];
 
   // The center frequency, in Hz, for uplinking in this plan. 0 if uplink is not available in
   // this plan.
   //
   // Deprecated. Use channel_set.uplink.center_frequency_hz.
-  uint64 uplink_center_frequency_hz = 12;
+  uint64 uplink_center_frequency_hz = 12 [deprecated = true];
 
   // Metadata for telemetry received during the pass. Only populated when the pass has completed
   // successfully and data processing is complete.


### PR DESCRIPTION
Center frequency is typically different for each channel set so we can't have these fields on the top level. The migration pattern is to use the `channel_set.uplink/downlink.center_frequency_hz`.

We're already doing this in `stellarcli`, for example, https://github.com/infostellarinc/stellarcli/blob/35ea08021a1928fbb0f511e208f000a3b35a5aa6/pkg/groundstation/plan/list_plans.go#L95