### PR TITLE
Remove pydocstring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ plugins {
 conda {
     'miniconda2-build' {
         packages.addAll('cmake', 'pandoc')
-        pythonPackages.addAll('conan', 'grpcio-tools', 'pdoc', 'protoc-docs-plugin', 'twine')
+        pythonPackages.addAll('conan', 'grpcio-tools', 'pdoc', 'twine')
     }
 }
 

--- a/stubs/python/build.gradle.kts
+++ b/stubs/python/build.gradle.kts
@@ -47,10 +47,6 @@ protobuf {
         register("grpc_python") {
             outputDir.set(file(packageDir))
         }
-
-        register("pydocstring") {
-            outputDir.set(file(packageDir))
-        }
     }
 }
 
@@ -120,14 +116,6 @@ tasks {
             file("$packageDir/stellarstation/api").walk()
                     .filter { it.isDirectory }
                     .forEach { file("$it/__init__.py").writeText("") }
-
-            // pydocstring puts non-ASCII characters into the files, breaking Python 2 compatibility.
-            file("$packageDir/stellarstation").walk()
-                    .filter { it.name.endsWith(".py") }
-                    .forEach {
-                        val fileContent = "# -*- coding: utf-8 -*-\n" + it.readText()
-                        it.writeText(fileContent)
-                    }
         }
     }
 


### PR DESCRIPTION
pydocstring ([protoc-docs-plugin](https://github.com/googleapis/protoc-docs-plugin)) hasn't been released for almost two years and it insert document strings into generated codes with old dictionaly syntax. Since it cause a syntax error, it should be removed. 