### PR TITLE
Rename RZ to DNRZ.

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -317,8 +317,9 @@ enum LineCoding {
   // https://en.wikipedia.org/wiki/Non-return-to-zero
   NRZ_S = 2;
 
-  // Return-to-zero. https://en.wikipedia.org/wiki/Return-to-zero
-  RZ = 3;
+  // Differential non-return-to-zero.
+  // https://en.wikipedia.org/wiki/Return-to-zero
+  DNRZ = 3;
 
   // Bipolar return-to-zero level.
   // https://en.wikipedia.org/wiki/Bipolar_encoding


### PR DESCRIPTION
I haven't been able to find a reliable source for the comment, maybe we shouldn't include the return to zero wikipedia comment. What do you think @vaelen ?