### PR TITLE
Remove deprecated center frequency fields.

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -430,18 +430,6 @@ message Pass {
   // The time of the max elevation during the pass.
   google.protobuf.Timestamp max_elevation_time = 8;
 
-  // The center frequency, in Hz, for downlinking in this pass. 0 if downlink is not available in
-  // this pass.
-  //
-  // Deprecated. Use channel_set.downlink.center_frequency_hz.
-  uint64 downlink_center_frequency_hz = 9 [deprecated = true];
-
-  // The center frequency, in Hz, for uplinking in this pass. 0 if uplink is not available in
-  // this pass.
-  //
-  // Deprecated. Use channel_set.uplink.center_frequency_hz.
-  uint64 uplink_center_frequency_hz = 10 [deprecated = true];
-
   // A mapping of channel set to its unique reservation token.
   message ChannelSetToken {
     // A channel set that can be reserved.
@@ -554,18 +542,6 @@ message Plan {
 
   // The time of the max elevation during the plan.
   google.protobuf.Timestamp max_elevation_time = 10;
-
-  // The center frequency, in Hz, for downlinking in this plan. 0 if downlink is not available in
-  // this plan.
-  //
-  // Deprecated. Use channel_set.downlink.center_frequency_hz.
-  uint64 downlink_center_frequency_hz = 11 [deprecated = true];
-
-  // The center frequency, in Hz, for uplinking in this plan. 0 if uplink is not available in
-  // this plan.
-  //
-  // Deprecated. Use channel_set.uplink.center_frequency_hz.
-  uint64 uplink_center_frequency_hz = 12 [deprecated = true];
 
   // Metadata for telemetry received during the pass. Only populated when the pass has completed
   // successfully and data processing is complete.


### PR DESCRIPTION
~These fields don't seem to be filled anymore.~

Still being filled, but requesting removal.