### PR TITLE
Add polarization to RadioDeviceConfiguration

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -42,6 +42,8 @@ message RadioDeviceConfiguration {
   // The protocol used by this device when doing RF communication. If unset, the device is only
   // demodulating / modulating without applying any higher-level communication protocol.
   CommunicationProtocol protocol = 4;
+
+  stellarstation.api.v1.antenna.AntennaPolarization polarization = 5;
 }
 
 // A communication protocol used with a radio device. These must contain all the parameters

--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -15,6 +15,8 @@
  */
 syntax = "proto3";
 
+import "stellarstation/api/v1/antenna/antenna.proto";
+
 package stellarstation.api.v1.radio;
 
 option go_package = "github.com/infostellarinc/go-stellarstation/api/v1/radio";

--- a/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
+++ b/api/src/main/proto/stellarstation/api/v1/radio/radio.proto
@@ -43,6 +43,7 @@ message RadioDeviceConfiguration {
   // demodulating / modulating without applying any higher-level communication protocol.
   CommunicationProtocol protocol = 4;
 
+  // The polarization of the antenna.
   stellarstation.api.v1.antenna.AntennaPolarization polarization = 5;
 }
 


### PR DESCRIPTION
It's required to configure devices based on polarization. A ground station that the capability to switch polarization will require this parameter.