### PR TITLE
Stop module metadata generation.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,4 +121,8 @@ task publishStubs {
     dependsOn ':stubs:python:uploadPythonPackage'
 }
 
+tasks.withType(GenerateModuleMetadata) {
+    enabled = false
+}
+
 tasks.checkNodeResolutions.enabled = false


### PR DESCRIPTION
This should let people use the snapshot without metadata adding deps to their project.