### PR TITLE
Add workflow for building on ubuntu

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -1,0 +1,61 @@
+# MIT License
+#
+# Copyright (c) 2019 Choko (choko@curioswitch.org)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+
+name: Continuous Build
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 10
+      - name: Cache Gradle Modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: gradle-caches
+      - name: Cache Gradle Wrapper
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/wrapper
+          key: gradle-wrapper
+      - name: Cache Curiostack
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/curiostack
+          key: ${{ runner.os }}-gradle-curiostack
+      - name: Execute continuousBuild
+        run: ./gradlew continuousBuild --stacktrace -Porg.curioswitch.curiostack.ci.disableCoverage=true
+        shell: bash
+        env:
+          CI: true

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -31,7 +31,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
           - ubuntu-latest
           - windows-latest
     steps:

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -32,7 +32,6 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          - windows-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v1

--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -32,6 +32,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - windows-latest
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v1


### PR DESCRIPTION
Circle CI reporting is weird and I think github actions are cleaner so I'd like to move away from circle CI and just use GH Actions for now. There are some issues in getting other OSes going, but I don't think we lose anything moving away from circle CI.