### PR TITLE
Add satellite ID and channel set fields to Plan message for ground st…

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
@@ -153,7 +153,7 @@ message ListPlansResponse {
 // A scheduled pass. The plan will be executed on its ground station to communicate with its satellite
 // during a time range between AOS and LOS, unless explicitly cancelled.
 //
-// Next ID: 14
+// Next ID: 16
 message Plan {
   // The ID of this plan.
   string plan_id = 1;
@@ -211,6 +211,16 @@ message Plan {
 
   // The price per minute (USD) for this plan set by the ground station owner at the time of reservation.
   double unit_price = 12;
+
+  // The id of the satellite to be tracked in the plan.
+  // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
+  //         incompatible ways in the future.
+  string satellite_id = 14;
+
+  // The channel set used to reserve this plan.
+  // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
+  //         incompatible ways in the future.
+  ChannelSet channel_set = 15;
 }
 
 // Unparsed TLE data for a satellite - https://en.wikipedia.org/wiki/Two-line_element_set


### PR DESCRIPTION
…ation

Currently, `Plan` message doesn't have satellite ID and channel set field. These are required for some use case. (e.g. match a satellite configuration on local scheduler with a channel set.)