### PR TITLE
Make telemetry repeated

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -282,8 +282,8 @@ message SatelliteStreamResponse {
   // minutes.
   string stream_id = 1;
 
-  // A response on the stream. Currently the only type of response is telemetry received from the
-  // satellite.
+  // A response on the stream. Currently the only types of response are telemetry received from the
+  // satellite and stream events.
   oneof Response {
     // A response from a satellite containing telemetry.
     ReceiveTelemetryResponse receive_telemetry_response = 2;
@@ -298,7 +298,7 @@ message SatelliteStreamResponse {
 // A response from a satellite containing telemetry.
 message ReceiveTelemetryResponse {
   // The telemetry received.
-  Telemetry telemetry = 1;
+  repeated Telemetry telemetry = 1;
 
   // The ID of the plan the telemetry was received for.
   string plan_id = 2;

--- a/examples/fakeserver/src/main/java/com/stellarstation/api/fakeserver/FakeStellarStationService.java
+++ b/examples/fakeserver/src/main/java/com/stellarstation/api/fakeserver/FakeStellarStationService.java
@@ -30,7 +30,6 @@ import io.grpc.StatusException;
 import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import java.time.Clock;
-import java.time.Duration;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -60,7 +59,7 @@ class FakeStellarStationService extends StellarStationServiceImplBase {
   public StreamObserver<SatelliteStreamRequest> openSatelliteStream(
       StreamObserver<SatelliteStreamResponse> responseObserver) {
     ServiceRequestContext ctx = RequestContext.current();
-    ctx.setRequestTimeout(Duration.ZERO);
+    ctx.clearRequestTimeout();
     ctx.setMaxRequestLength(0);
     ScheduledFuture<?> future =
         ctx.eventLoop()
@@ -116,7 +115,7 @@ class FakeStellarStationService extends StellarStationServiceImplBase {
         SatelliteStreamResponse.newBuilder()
             .setReceiveTelemetryResponse(
                 ReceiveTelemetryResponse.newBuilder()
-                    .setTelemetry(
+                    .addTelemetry(
                         Telemetry.newBuilder()
                             .setTimeFirstByteReceived(
                                 Timestamps.fromMillis(Clock.systemUTC().millis()))

--- a/examples/java/printing-client/src/main/java/com/stellarstation/api/examples/printingclient/PrintingClientMain.java
+++ b/examples/java/printing-client/src/main/java/com/stellarstation/api/examples/printingclient/PrintingClientMain.java
@@ -24,6 +24,7 @@ import com.stellarstation.api.v1.SatelliteStreamResponse;
 import com.stellarstation.api.v1.SendSatelliteCommandsRequest;
 import com.stellarstation.api.v1.StellarStationServiceGrpc;
 import com.stellarstation.api.v1.StellarStationServiceGrpc.StellarStationServiceStub;
+import com.stellarstation.api.v1.Telemetry;
 import io.grpc.ManagedChannel;
 import io.grpc.auth.MoreCallCredentials;
 import io.grpc.netty.GrpcSslContexts;
@@ -67,16 +68,15 @@ public class PrintingClientMain {
             new StreamObserver<>() {
               @Override
               public void onNext(SatelliteStreamResponse value) {
+                var telemetry =
+                    ByteString.copyFrom(
+                        value.getReceiveTelemetryResponse().getTelemetryList().stream()
+                                .map(Telemetry::getData)
+                            ::iterator);
+
                 logger.info(
                     "Got response: {}",
-                    Base64.getEncoder()
-                        .encodeToString(
-                            value
-                                .getReceiveTelemetryResponse()
-                                .getTelemetry()
-                                .getData()
-                                .toByteArray())
-                        .substring(0, 100));
+                    Base64.getEncoder().encodeToString(telemetry.toByteArray()).substring(0, 100));
               }
 
               @Override

--- a/integration-tests/java/src/integration-test/java/com/stellarstation/api/test/satellite/SatelliteStreamerTest.java
+++ b/integration-tests/java/src/integration-test/java/com/stellarstation/api/test/satellite/SatelliteStreamerTest.java
@@ -62,7 +62,7 @@ public class SatelliteStreamerTest {
 
     class TelemetryAndCommandTestStreamObserver implements StreamObserver<SatelliteStreamResponse> {
       private boolean isClosing;
-      private final List<Integer> safeModeStates = new ArrayList();
+      private final List<Integer> safeModeStates = new ArrayList<>();
       private int telemetryReceived;
 
       @Override
@@ -72,7 +72,8 @@ public class SatelliteStreamerTest {
         }
 
         if (response.hasReceiveTelemetryResponse()) {
-          ByteString data = response.getReceiveTelemetryResponse().getTelemetry().getData();
+          ByteString data =
+              response.getReceiveTelemetryResponse().getTelemetryList().get(0).getData();
           if (data.size() > 2) {
             // The second last byte of the telemetry indicates the current state of the
             // fake satellite used in the test. The value is either of 0 or 1.

--- a/integration-tests/java/src/integration-test/java/com/stellarstation/api/test/satellite/SatelliteStreamerTest.java
+++ b/integration-tests/java/src/integration-test/java/com/stellarstation/api/test/satellite/SatelliteStreamerTest.java
@@ -27,6 +27,7 @@ import com.stellarstation.api.test.auth.ApiClientModule;
 import com.stellarstation.api.v1.SatelliteStreamRequest;
 import com.stellarstation.api.v1.SatelliteStreamResponse;
 import com.stellarstation.api.v1.SendSatelliteCommandsRequest;
+import com.stellarstation.api.v1.Telemetry;
 import com.stellarstation.api.v1.monitoring.AntennaState;
 import dagger.Component;
 import io.grpc.stub.StreamObserver;
@@ -73,7 +74,10 @@ public class SatelliteStreamerTest {
 
         if (response.hasReceiveTelemetryResponse()) {
           ByteString data =
-              response.getReceiveTelemetryResponse().getTelemetryList().get(0).getData();
+              ByteString.copyFrom(
+                  response.getReceiveTelemetryResponse().getTelemetryList().stream()
+                          .map(Telemetry::getData)
+                      ::iterator);
           if (data.size() > 2) {
             // The second last byte of the telemetry indicates the current state of the
             // fake satellite used in the test. The value is either of 0 or 1.


### PR DESCRIPTION
Motivation here is to improve the performance with high bitrates. On the server side we have to serialize/deserialize thousands of `Telemetry` messages per second and send them one by one which can cause memory issues. 

I propose we set the `Telemetry` message to be repeated to provide (close to) a straight-through path for the telemetry.

⚠️ Although single -> repeated field changes are wire compatible, any clients using old version of the API will only receive the first `Telemetry` message. Another option is to create a new field and deprecate the existing field, but that might have implications on the server since we would have to support both simultaneously (maybe we can do a temporary workaround for high-bitrate satellites).