### PR TITLE
fake api server - add plan id & msg ack id

### DIFF
--- a/examples/fakeserver/README.md
+++ b/examples/fakeserver/README.md
@@ -7,7 +7,7 @@ integrating with the service.
 
 - Verifies a fake API key
 - Returns 1MB of random telemetry every second
-- Echos back received commands
+- Echos back received commands (except for TelemetryReceivedAck)
 - Cancels the connection after 5 minutes
 - Only allows requests for satellite ID `"5"`, other IDs show behavior for non-existent satellites
 

--- a/examples/fakeserver/src/main/java/com/stellarstation/api/fakeserver/FakeStellarStationService.java
+++ b/examples/fakeserver/src/main/java/com/stellarstation/api/fakeserver/FakeStellarStationService.java
@@ -52,8 +52,8 @@ import org.apache.logging.log4j.Logger;
 class FakeStellarStationService extends StellarStationServiceImplBase {
   private final FakeServerConfig config;
   private static final Logger logger = LogManager.getLogger();
-  final static String SATELLITE_ID = "5";
-  final static String FAKE_PLAN_ID = System.currentTimeMillis() + "";
+  static final String SATELLITE_ID = "5";
+  static final String FAKE_PLAN_ID = System.currentTimeMillis() + "";
   static long sendCounter = 1;
 
   @Inject
@@ -92,8 +92,7 @@ class FakeStellarStationService extends StellarStationServiceImplBase {
         }
         if (value.hasTelemetryReceivedAck()) {
           logger.info("received TelemetryReceivedAck message: \n" + value);
-        }
-        else {
+        } else {
           for (ByteString payload : value.getSendSatelliteCommandsRequest().getCommandList()) {
             sendTelemetry(payload, responseObserver);
           }
@@ -135,8 +134,8 @@ class FakeStellarStationService extends StellarStationServiceImplBase {
                                     Clock.systemUTC().millis() + TimeUnit.SECONDS.toMillis(1)))
                             .setData(payload)
                             .build())
-                        .setPlanId(FAKE_PLAN_ID)
-                        .setMessageAckId(SATELLITE_ID + ":" + FAKE_PLAN_ID + ":" + sendCounter++)
+                    .setPlanId(FAKE_PLAN_ID)
+                    .setMessageAckId(SATELLITE_ID + ":" + FAKE_PLAN_ID + ":" + sendCounter++)
                     .build())
             .build();
     responseObserver.onNext(response);


### PR DESCRIPTION
- Update fake-api-server to add support for TelemetryReceivedAck. Also, plan-id is now sent with Telemetry Data to emulate real server message.
- This also fixes `--stats` feature for stellarcli when connecting to fake-api-server

- note on `- Echos back received commands` 
Should we remove this? I believe this doesn't happen in our actual server.