### PR TITLE
Bundle all metadata into a single message for better serialization.

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -676,7 +676,7 @@ message PlanMetadata {
     repeated string data = 1;
   }
 
-  map<string,Metadata> metadata = 2;
+  map<string, Metadata> metadata = 2;
 }
 
 // Request for the `SetPlanMetadata` method.

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -672,7 +672,11 @@ message SetTleSourceResponse {
 // Message to be nested inside of a SetPlanMetadataRequest message in order to
 // get around the limitation of protobuf maps not allowing repeated values.
 message PlanMetadata {
-  repeated string data = 1;
+  message Metadata {
+    repeated string data = 1;
+  }
+
+  map<string,Metadata> metadata = 2;
 }
 
 // Request for the `SetPlanMetadata` method.
@@ -683,7 +687,7 @@ message SetPlanMetadataRequest {
   string plan_id = 1;
 
   // The metadata to set.
-  map<string, PlanMetadata> metadata = 2;
+  PlanMetadata metadata = 2;
 }
 
 // Response for the `SetPlanMetadata` method.


### PR DESCRIPTION
This allows serialization of the entire `Metadata` message which is helpful since the map doesn't have built-in serialization and parsing functions. 