### PR TITLE
Remove unused timestamp import from monitoring proto.

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/monitoring/monitoring.proto
+++ b/api/src/main/proto/stellarstation/api/v1/monitoring/monitoring.proto
@@ -15,7 +15,6 @@
  */
 syntax = "proto3";
 
-import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 import "stellarstation/api/v1/antenna/antenna.proto";
 import "stellarstation/api/v1/common/common.proto";


### PR DESCRIPTION
Just gets rid of a warning.