### PR TITLE
Add plan id to open satellite stream request

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -82,7 +82,8 @@ service StellarStationService {
   // as it is made available. All telemetry received from the satellite on reserved passes along
   // with associated events from this point on will be returned as soon as this method is called. If
   // `SatelliteStreamRequest.stream_id` is specified, any messages that have been buffered for the
-  // stream will be returned as well.
+  // stream will be returned as well. If `SatelliteStreamRequest.plan_id` is provided, only messages
+  // for the specified plan will be returned.
   //
   // The first `SatelliteStreamRequest` sent on the stream is used for configuring the stream.
   // Unless otherwise specified, all configuration is taken from the first request and configuration

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -171,11 +171,19 @@ service StellarStationService {
 
 // Request for the `OpenSatelliteStream` method.
 //
-// Next ID: 8
+// Next ID: 12
 message SatelliteStreamRequest {
   // The ID of the satellite to open a stream with. The ID of a satellite can be found on the
   // StellarStation Console page for the satellite.
   string satellite_id = 1;
+
+  // The ID of the plan to open a stream for. If `plan_id` is set only messages for the provided
+  // plan ID will be returned on this stream. A valid `plan_id` can be found in the response for
+  // the `ListPlans` method or on the StellarStation Console page for the satellite.
+  //
+  // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
+  //         incompatible ways in the future.
+  string plan_id = 11;
 
   // The `SatelliteStreamResponse.stream_id` from a previously opened stream to resume. If the
   // specified stream has already expired or been closed, the stream is closed with a `ABORTED`

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -178,7 +178,7 @@ message SatelliteStreamRequest {
   // StellarStation Console page for the satellite.
   string satellite_id = 1;
 
-  // The ID of the plan to open a stream for. If `plan_id` is set only messages for the provided
+  // The ID of the plan to open a stream for. If `plan_id` is set, only messages for the provided
   // plan ID will be returned on this stream. A valid `plan_id` can be found in the response for
   // the `ListPlans` method or on the StellarStation Console page for the satellite.
   //


### PR DESCRIPTION
This PR adds a new field, `plan_id` to the SatelliteStreamRequest. The purpose of this field is to tell the stream to only return messages for the provided `plan_id`. 

This is part of a broader effort to move away from long-living streams and to stream on a per-plan basis. More detailed reasoning and explanations will happen in an upcoming API release, but if there is any early discussion it can happen here.

I would like this field to become mandatory eventually since it simplifies the way we provide streaming services on StellarStation. Additionally, it would remove ambiguity of commanding a satellite when multiple plans are active, effectively deprecating the `SendSatelliteCommandsRequest.channel_set_id` field.

This means that current users of the `OpenSatelliteStream` RPC should consider moving to a per-plan pattern of streaming for easier migration in the future. Most users are already automating the opening and closing of streams based off of scheduled plans, but for those who haven't, the workflow is similar to this:
1. Schedule passes on StellarStation
2. ListPlans
3. Open the stream 2 minutes before plan start, a timestamp that is returned in `ListPlansResponse`
4. Close the stream at the end of the plan, either at plan end or using some other deterministic method (waiting for data to stop, for example)
5. Repeat

Once per-plan streaming becomes required, the only changes would happen in step 3 where instead of providing the `satellite_id` inside of `SatelliteStreamRequest`, both `satellite_id` and `plan_id` should be set.

No obsolescence schedule is available yet, but we will make an official announcement likely with the release of 0.11.0, so stay tuned and reach out to support@stellarstation.com if you have trouble supporting per-plan streaming.