### PR TITLE
Publish stub to Maven Central

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -15,9 +15,9 @@
  */
 
 plugins {
-    id 'com.jfrog.artifactory' version '4.13.0'
     id 'org.curioswitch.gradle-grpc-api-plugin'
     id 'maven-publish'
+    id 'signing'
 }
 
 archivesBaseName = 'stellarstation-api'
@@ -35,25 +35,28 @@ publishing {
             }
         }
     }
+    repositories {
+        maven {
+            if (version.startsWith('0.0.0')) {
+                // snapshot
+                url = 'https://oss.sonatype.org/content/repositories/snapshots'
+            } else {
+                // release
+                url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+            }
+            credentials {
+                username = rootProject.findProperty('maven.user')
+                password = rootProject.findProperty('maven.key')
+            }
+        }
+    }
 }
 
-artifactory {
-    contextUrl = 'https://oss.jfrog.org'
-    publish {
-        repository {
-            repoKey = 'oss-snapshot-local'
-            username = rootProject.findProperty('bintray.user')
-            password = rootProject.findProperty('bintray.key')
-        }
-        defaults {
-            publications 'maven'
-            publishArtifacts = true
-            publishPom = true
-        }
-    }
-    resolve {
-        repoKey = 'jcenter'
-    }
+signing {
+    sign publishing.publications.maven
+    keyId = rootProject.findProperty('sign.keyId')
+    password = rootProject.findProperty('sign.password')
+    secretKeyRingFile = rootProject.findProperty('sign.keyFile')
 }
 
 afterEvaluate {

--- a/build.gradle
+++ b/build.gradle
@@ -63,35 +63,7 @@ allprojects {
     }
 
     plugins.withType(MavenPublishPlugin) {
-        project.apply plugin: 'com.jfrog.bintray'
-        // This should happen automatically, not clear why not.
-        tasks.bintrayUpload.dependsOn tasks.publishToMavenLocal
-
-        def bintrayUser = findProperty('bintray.user')
-        def bintrayKey = findProperty('bintray.key')
-
         afterEvaluate {
-            bintray {
-                publish = true
-                user = bintrayUser
-                key = bintrayKey
-                pkg {
-                    name = project.archivesBaseName
-                    repo = 'stellarstation'
-                    userOrg = 'infostellarinc'
-                    licenses = ['Apache-2.0']
-                    vcsUrl = 'https://github.com/infostellarinc/stellarstation-api.git'
-                    githubRepo = 'infostellarinc/stellarstation-api'
-                    version {
-                        name = project.version
-                        gpg {
-                            sign = true
-                        }
-                    }
-                }
-                publications = ['maven']
-            }
-
             publishing {
                 publications {
                     maven(MavenPublication) {
@@ -109,9 +81,9 @@ allprojects {
                             }
                             developers {
                                 developer {
-                                    id = 'rag'
-                                    name = 'Anuraag Agrawal'
-                                    email = 'rag@istellar.jp'
+                                    id = 'istellar'
+                                    name = ''
+                                    email = 'sonatype@istellar.com'
                                     organization = 'Infostellar, Inc.'
                                     organizationUrl = 'https://www.infostellar.net/'
                                 }
@@ -138,7 +110,7 @@ allprojects {
 //   npm.key
 task publishStubs {
     description 'Publishes API stubs (only works for non-snapshot versions)'
-    dependsOn ':api:bintrayUpload'
+    dependsOn ':api:publish'
     dependsOn ':stubs:golang:gitPublishCommit'
     dependsOn ':stubs:nodejs:publish'
     dependsOn ':stubs:python:uploadPythonPackage'


### PR DESCRIPTION
Due to the EOL of bintray and jcenter, this will upload both snapshot and release stub to maven central directly.