### PR TITLE
Publish stub to Maven Central

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -45,18 +45,20 @@ publishing {
                 url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
             }
             credentials {
-                username = rootProject.findProperty('maven.user')
-                password = rootProject.findProperty('maven.key')
+                username = rootProject.findProperty('maven.username')
+                password = rootProject.findProperty('maven.password')
             }
         }
     }
 }
 
 signing {
+    // Need to set the following project properties
+    //   signing.keyId=24875D73 // last 8 characters of key ID
+    //   signing.password=secret // secret key passphrase
+    //   signing.secretKeyRingFile=/home/user/.gnupg/secring.gpg // path to secret keyring in `gpg` format
+    // https://docs.gradle.org/current/userguide/signing_plugin.html#sec:signatory_credentials
     sign publishing.publications.maven
-    keyId = rootProject.findProperty('sign.keyId')
-    password = rootProject.findProperty('sign.password')
-    secretKeyRingFile = rootProject.findProperty('sign.keyFile')
 }
 
 afterEvaluate {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -15,9 +15,9 @@
  */
 
 plugins {
-    id 'com.jfrog.artifactory' version '4.13.0'
     id 'org.curioswitch.gradle-grpc-api-plugin'
     id 'maven-publish'
+    id 'signing'
 }
 
 archivesBaseName = 'stellarstation-api'
@@ -35,25 +35,28 @@ publishing {
             }
         }
     }
+    repositories {
+        maven {
+            if (version.startsWith('0.0.0')) {
+                // snapshot
+                url = 'https://oss.sonatype.org/content/repositories/snapshots'
+            } else {
+                // release
+                url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2'
+            }
+            credentials {
+                username = rootProject.findProperty('maven.user')
+                password = rootProject.findProperty('maven.key')
+            }
+        }
+    }
 }
 
-artifactory {
-    contextUrl = 'https://oss.jfrog.org'
-    publish {
-        repository {
-            repoKey = 'oss-snapshot-local'
-            username = rootProject.findProperty('bintray.user')
-            password = rootProject.findProperty('bintray.key')
-        }
-        defaults {
-            publications 'maven'
-            publishArtifacts = true
-            publishPom = true
-        }
-    }
-    resolve {
-        repoKey = 'jcenter'
-    }
+signing {
+    sign publishing.publications.maven
+    keyId = rootProject.findProperty('sign.keyId')
+    password = rootProject.findProperty('sign.password')
+    secretKeyRingFile = rootProject.findProperty('sign.keyFile')
 }
 
 afterEvaluate {

--- a/build.gradle
+++ b/build.gradle
@@ -102,11 +102,14 @@ allprojects {
     }
 }
 
-// To use this task the following properties should be set in your gradle.properties:
+// To use this task, need to set the following gradle properties:
+//   maven.username
+//   maven.password
+//   signing.keyId
+//   signing.password
+//   signing.secretKeyRingFile
 //   pypi.user
 //   pypi.password
-//   bintray.user
-//   bintray.key
 //   npm.key
 task publishStubs {
     description 'Publishes API stubs (only works for non-snapshot versions)'

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ allprojects {
                             developers {
                                 developer {
                                     id = 'istellar'
-                                    name = ''
+                                    name = 'Infostellar, Inc.'
                                     email = 'sonatype@istellar.com'
                                     organization = 'Infostellar, Inc.'
                                     organizationUrl = 'https://www.infostellar.net/'
@@ -110,7 +110,7 @@ allprojects {
 //   npm.key
 task publishStubs {
     description 'Publishes API stubs (only works for non-snapshot versions)'
-    dependsOn ':api:publish'
+    dependsOn ':api:publishMavenPublicationToMavenRepository'
     dependsOn ':stubs:golang:gitPublishCommit'
     dependsOn ':stubs:nodejs:publish'
     dependsOn ':stubs:python:uploadPythonPackage'

--- a/build.gradle
+++ b/build.gradle
@@ -63,35 +63,7 @@ allprojects {
     }
 
     plugins.withType(MavenPublishPlugin) {
-        project.apply plugin: 'com.jfrog.bintray'
-        // This should happen automatically, not clear why not.
-        tasks.bintrayUpload.dependsOn tasks.publishToMavenLocal
-
-        def bintrayUser = findProperty('bintray.user')
-        def bintrayKey = findProperty('bintray.key')
-
         afterEvaluate {
-            bintray {
-                publish = true
-                user = bintrayUser
-                key = bintrayKey
-                pkg {
-                    name = project.archivesBaseName
-                    repo = 'stellarstation'
-                    userOrg = 'infostellarinc'
-                    licenses = ['Apache-2.0']
-                    vcsUrl = 'https://github.com/infostellarinc/stellarstation-api.git'
-                    githubRepo = 'infostellarinc/stellarstation-api'
-                    version {
-                        name = project.version
-                        gpg {
-                            sign = true
-                        }
-                    }
-                }
-                publications = ['maven']
-            }
-
             publishing {
                 publications {
                     maven(MavenPublication) {
@@ -109,9 +81,9 @@ allprojects {
                             }
                             developers {
                                 developer {
-                                    id = 'rag'
-                                    name = 'Anuraag Agrawal'
-                                    email = 'rag@istellar.jp'
+                                    id = 'istellar'
+                                    name = ''
+                                    email = 'sonatype@istellar.com'
                                     organization = 'Infostellar, Inc.'
                                     organizationUrl = 'https://www.infostellar.net/'
                                 }
@@ -138,7 +110,7 @@ allprojects {
 //   npm.key
 task publishStubs {
     description 'Publishes API stubs (only works for non-snapshot versions)'
-    dependsOn ':api:bintrayUpload'
+    dependsOn ':api:publish'
     dependsOn ':stubs:golang:gitPublishCommit'
     dependsOn ':stubs:nodejs:publish'
     dependsOn ':stubs:python:uploadPythonPackage'

--- a/cloudbuild/release-publish.yaml
+++ b/cloudbuild/release-publish.yaml
@@ -1,3 +1,5 @@
+# CURRENTLY BROKEN, WORK IN PROGRESS TO FIX
+
 secrets:
   - kmsKeyName: projects/infostellar-cluster/locations/us-central1/keyRings/cloudbuild/cryptoKeys/deploy-stubs
     secretEnv:

--- a/cloudbuild/snapshot-publish.yaml
+++ b/cloudbuild/snapshot-publish.yaml
@@ -1,3 +1,5 @@
+# CURRENTLY BROKEN, WORK IN PROGRESS TO FIX
+
 secrets:
 - kmsKeyName: projects/infostellar-cluster/locations/us-central1/keyRings/cloudbuild/cryptoKeys/deploy-stubs
   secretEnv:


### PR DESCRIPTION
Building on top of branch created by @koncha99 

Allows publishing to Sonatype repositories, for syncing to Maven Central.

Cleaned up some configuration code, while using the same core logic provided by @koncha99 