### PR TITLE
Support latest version of API in printing client. Tweak readme.

### DIFF
--- a/examples/python/printing-client/README.md
+++ b/examples/python/printing-client/README.md
@@ -3,6 +3,12 @@
 A simple example client that prints received telemetry and sends commands at a fixed interval. Shows
 the basics of writing code to integrate with the StellarStation API. Only works with [Fakeserver](../../fakeserver).
 
+## Create and activate a venv for printing-client
+
+```bash
+$ python3 -m venv venv
+$ source venv/bin/activate
+```
 
 ## Install Google authentication library for Python
 For authentication, install google-auth by running:
@@ -20,5 +26,5 @@ $  pip install --upgrade stellarstation
 ## Try it out!
 Now, you'll see response from fakeserver by running printing-client.
 ```bash
-$  python printing-client.py
+$  python3 printing-client.py
 ```

--- a/examples/python/printing-client/README.md
+++ b/examples/python/printing-client/README.md
@@ -10,17 +10,9 @@ $ python3 -m venv venv
 $ source venv/bin/activate
 ```
 
-## Install Google authentication library for Python
-For authentication, install google-auth by running:
+## Install requirements
 ```bash
-$ pip install --upgrade google-auth
-```
-
-## Install StellarStation API library
-After installation of required modules, you need stubs generated from .proto file. To install precompiled client stubs for Python, run:
-
-```bash
-$  pip install --upgrade stellarstation
+$ pip install -r requirements.txt
 ```
 
 ## Try it out!

--- a/examples/python/printing-client/printing-client.py
+++ b/examples/python/printing-client/printing-client.py
@@ -50,10 +50,10 @@ def run():
 
     for response in client.OpenSatelliteStream(request_iterator):
         if response.HasField("receive_telemetry_response"):
-            print(
-                "Got response: ",
-                base64.b64encode(
-                    response.receive_telemetry_response.telemetry.data)[:100])
+            for telemetry in response.receive_telemetry_response.telemetry:
+              print(
+                  "Got response: ",
+                  base64.b64encode(telemetry.data)[:100])
 
             command = [
                 bytes(b'a' * 5000),

--- a/examples/python/printing-client/requirements.txt
+++ b/examples/python/printing-client/requirements.txt
@@ -1,0 +1,9 @@
+cachetools==4.2.2
+google-auth==1.30.0
+grpcio==1.37.1
+protobuf==3.17.0
+pyasn1==0.4.8
+pyasn1-modules==0.2.8
+rsa==4.7.2
+six==1.16.0
+stellarstation==0.10.0


### PR DESCRIPTION
A change of telemetry data format in [stellarstation-api v0.9.0](https://github.com/infostellarinc/stellarstation-api/releases/tag/0.9.0) broke this example. Fix was simple as seen in this PR.

I also included a `requirements.txt` for better stability of this example. API changes are almost always backwards-compatible, but examples are not guaranteed to be forward-compatible-- locking the API version with `requirements.txt` will give us a way to maintain this.

Fixes #249