### PR TITLE
Fix conda deps

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,8 +26,8 @@ plugins {
 
 conda {
     'miniconda-build' {
-        packages.addAll('cmake', 'pandoc')
-        pythonPackages.addAll('conan', 'grpcio-tools', 'pdoc', 'twine')
+        packages.addAll('cmake==3.14.0', 'pandoc')
+        pythonPackages.addAll('conan==1.37.2', 'grpcio-tools==1.38.0', 'pdoc==7.1.1', 'twine==3.4.1')
     }
 }
 


### PR DESCRIPTION
Seems like the culprit was cmake. Pinning to 3.14.0 seems to let miniconda tasks succeed.