### PR TITLE
Fix `snapshot-publish.yaml`

### DIFF
--- a/cloudbuild/snapshot-publish.yaml
+++ b/cloudbuild/snapshot-publish.yaml
@@ -1,5 +1,8 @@
-# CURRENTLY BROKEN, WORK IN PROGRESS TO FIX
-
+secrets:
+  - kmsKeyName: projects/infostellar-cluster/locations/us-central1/keyRings/cloudbuild/cryptoKeys/deploy-stubs
+    secretEnv:
+      MAVEN_PASSWORD: CiQAo3bGoYXB3hVouZrQjQ49Na9nyfRP9p2eei0qkWApr6bAziISVQD6f46OpEZCBVyO4jUoPzlmBdv1GGV8r8AxPZVYcqfR8uqUZEzwht2tnmkN9UxGEtAe6RAr5XNh2YTlVCTmQ4oHVklPb6NgqzgOiCg/bB+uYXXqros=
+      SIGNING_PASSWORD: CiQAo3bGoVnvC+dNthiI+dAFswbsvn9/j9a3TW8javB0kFQmDyoSSQD6f46O064kepbO3EoGMcB1Zu9iCJSk3tjkHc/Rl3SUjcr18R85/lWiWWi7tVu7J0Vkdbs3wncKaAr93uUWV9WqQH5LKcwNlGk=
 steps:
 - name: gcr.io/cloud-builders/gcloud
   args:
@@ -10,6 +13,15 @@ steps:
   - --location=us-central1
   - --keyring=cloudbuild
   - --key=deploy-stubs
+- name: gcr.io/cloud-builders/gcloud
+  args:
+    - kms
+    - decrypt
+    - --ciphertext-file=cloudbuild/secring.gpg.enc
+    - --plaintext-file=cloudbuild/secring.gpg
+    - --location=us-central1
+    - --keyring=cloudbuild
+    - --key=deploy-stubs
 - name: curiostack/java-cloud-builder
   entrypoint: bash
   args:
@@ -21,7 +33,7 @@ steps:
     cp cloudbuild/id_rsa /root/.ssh/id_rsa &&
     chmod 400 /root/.ssh/id_rsa &&
     echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> /root/.ssh/config &&
-    ./gradlew :stubs:golang:gitPublishPush --stacktrace --no-daemon
+    ./gradlew -Pmaven.username=UpVSp/UZ -Pmaven.password=$$MAVEN_PASSWORD -Psigning.secretKeyRingFile="$(pwd)/cloudbuild/secring.gpg" -Psigning.keyId=C8772BE9 -Psigning.password=$$SIGNING_PASSWORD :api:publishMavenPublicationToMavenRepository :stubs:golang:gitPublishPush --stacktrace --no-daemon
   env:
     - CI=true
     - CI_MASTER=true


### PR DESCRIPTION
Added `:api:publishMavenPublicationToMavenRepository` logic to `snapshot-publish.yaml`, which now publishes to Sonatype OSSRH and is equivalent to how we previously ran the `:api:artifactoryPublish` task.

The decision to publish to `https://oss.sonatype.org/content/repositories/snapshots` instead of `/release` is determined by the artifact `version`.