### PR TITLE
Added API definitions for Execution Time

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -416,6 +416,16 @@ message ReservePassRequest {
   // The token that specifies the pass, as returned in `Pass.reservation_token` or one of the
   // `Pass.channel_set_token.reservation_token` values.
   string reservation_token = 1;
+
+  // Execution start time
+  //
+  // Optional. But if set execution_end_time must also be set.
+  google.protobuf.Timestamp execution_start_time = 2;
+
+  // Execution end time
+  //
+  // Optional. But if set execution_start_time must also be set.
+  google.protobuf.Timestamp execution_end_time = 3;
 }
 
 // Response for the `ReservePass` method.
@@ -545,7 +555,7 @@ message TelemetryMetadata {
 
 // A plan, specifying a time range within which a satellite will be communicated with.
 //
-// Next ID: 21
+// Next ID: 23
 message Plan {
   // The unique ID of the plan.
   string id = 1;
@@ -629,6 +639,12 @@ message Plan {
 
   // The price per minute (USD) for this plan set by the ground station owner at the time of reservation.
   double unit_price = 19;
+
+  // Execution start time
+  google.protobuf.Timestamp execution_start_time = 21;
+
+  // Execution end time
+  google.protobuf.Timestamp execution_end_time = 22;
 }
 
 // Request for the 'AddTle' method.
@@ -713,4 +729,25 @@ message SetPlanMetadataRequest {
 // Response for the `SetPlanMetadata` method.
 message SetPlanMetadataResponse {
   // Currently no payload in the response.
+}
+
+message SetPlanExecutionTimeResponse {
+  // Currently no payload in the response.
+}
+
+message SetPlanExecutionTimeRequest {
+  // The ID of the plan to set the execution time for.
+  //
+  // Required.
+  string plan_id = 1;
+
+  // Execution start time
+  //
+  // Required.
+  google.protobuf.Timestamp execution_start_time = 2;
+
+  // Execution end time
+  //
+  // Required.
+  google.protobuf.Timestamp execution_end_time = 3;
 }


### PR DESCRIPTION
Execution time can be passed alongside the reservation token when reserving a pass.

Added a method of setting the execution time based on plan ID.