### PR TITLE
STS-470: Update conan version to 1.48.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ plugins {
 conda {
     'miniconda-build' {
         packages.addAll('cmake==3.14.0', 'pandoc')
-        pythonPackages.addAll('conan==1.37.2', 'grpcio-tools==1.38.0', 'pdoc==7.1.1', 'twine==3.4.1')
+        pythonPackages.addAll('conan==1.48.0', 'grpcio-tools==1.38.0', 'pdoc==7.1.1', 'twine==3.4.1')
     }
 }
 

--- a/gradle/get-jdk.sh
+++ b/gradle/get-jdk.sh
@@ -41,16 +41,16 @@ export JAVA_HOME="$OPENJDK_DIR/jdk-16.0.1+9"
 DEST="$OPENJDK_DIR/jdk-16.0.1+9.tar.gz.or.zip"
 
 if "$linux" = "true"; then
-  SRC="https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16.0.1%2B9/OpenJDK16U-jdk_x64_linux_hotspot_16.0.1_9.tar.gz"
+  SRC="https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_x64_linux_hotspot_16.0.2_7.tar.gz"
 fi
 
 if "$darwin" = "true"; then
-  SRC="https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16.0.1%2B9/OpenJDK16U-jdk_x64_mac_hotspot_16.0.1_9.tar.gz"
+  SRC="https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_x64_mac_hotspot_16.0.2_7.tar.gz"
   export JAVA_HOME="$JAVA_HOME/Contents/Home"
 fi
 
 if "$windows" = "true"; then
-  SRC="https://github.com/AdoptOpenJDK/openjdk16-binaries/releases/download/jdk-16.0.1%2B9/OpenJDK16U-jdk_x64_windows_hotspot_16.0.1_9.zip"
+  SRC="https://github.com/adoptium/temurin16-binaries/releases/download/jdk-16.0.2%2B7/OpenJDK16U-jdk_x64_windows_hotspot_16.0.2_7.zip"
 fi
 
 if [ ! -d "$JAVA_HOME" ]; then


### PR DESCRIPTION
- **Problem:** Local builds fail. The `:stubs:cpp:downloadConanDeps` gradle task fails with error `ImportError: cannot import name 'soft_unicode' from 'markupsafe'`
- **Cause:** conan versions < 1.44.0 no longer work with markupsafe (see https://github.com/conan-io/conan/issues/10611 for more details)
- **Fix:** bump conan version from 1.37.2 to 1.48.0 (the latest version)