### PR TITLE
[STS-636] Add ground_station_id, channel_set_id(s), satellite_id to SatelliteStreamRequest & ReceiveTelemetryResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Gradle users should add the `stellarstation-api` artifact to their `dependencies
 
 ```groovy
 dependencies {
-    compile 'com.stellarstation.api:stellarstation-api:0.12.0'
+    compile 'com.stellarstation.api:stellarstation-api:0.13.0'
 }
 ```
 
@@ -43,7 +43,7 @@ Maven users would add to their `pom.xml`
   <dependency>
     <groupId>com.stellarstation.api</groupId>
     <artifactId>stellarstation-api</artifactId>
-    <version>0.12.0</version>
+    <version>0.13.0</version>
   </dependency>
 </dependencies>
 ```

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -185,6 +185,22 @@ message SatelliteStreamRequest {
   //         incompatible ways in the future.
   string plan_id = 11;
 
+  // Optional. The ID of the ground station to open a stream with. `satellite_id` must also be set when
+  // specifying `ground_station_id`. Only messages for the provided `ground_station_id` from the provided
+  // `satellite_id` will be returned on this stream.
+  //
+  // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
+  //         incompatible ways in the future.
+  string ground_station_id = 12;
+
+  // Optional. The ID of the channel set to open a stream with. `satellite_id` must also be set when
+  // specifying `channel_set_id`. Only messages from the provided `satellite_id` with the provided
+  // `channel_set_id` will be returned on this stream.
+  //
+  // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
+  //         incompatible ways in the future.
+  string channel_set_id = 13;
+
   // The `SatelliteStreamResponse.stream_id` from a previously opened stream to resume. If the
   // specified stream has already expired or been closed, the stream is closed with a `ABORTED`
   // error.
@@ -373,6 +389,12 @@ message ReceiveTelemetryResponse {
 
   // The ID of the plan the telemetry was received for.
   string plan_id = 2;
+
+  // The ID of the ground station.
+  string ground_station_id = 4;
+
+  // The ID of the channel set.
+  string channel_set_id = 5;
 
   // The ID to be used to when creating a `ReceiveTelemetryAck.message_ack_id` response
   //

--- a/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/stellarstation.proto
@@ -390,11 +390,14 @@ message ReceiveTelemetryResponse {
   // The ID of the plan the telemetry was received for.
   string plan_id = 2;
 
+  // The ID of the sattelite.
+  string satellite_id = 4;
+
   // The ID of the ground station.
-  string ground_station_id = 4;
+  string ground_station_id = 5;
 
   // The ID of the channel set.
-  string channel_set_id = 5;
+  string channel_set_id = 6;
 
   // The ID to be used to when creating a `ReceiveTelemetryAck.message_ack_id` response
   //

--- a/integration-tests/java/README.md
+++ b/integration-tests/java/README.md
@@ -47,7 +47,7 @@ In order to run these tests in your own copy of the source code, you need to upd
 on stellarstation-api from an internal reference to the external one.
 
 To do that, open `build.gradle` and replace `implementation project(':api')` in dependencies section with
-`implementation 'com.stellarstation.api:stellarstation-api:0.12.0'`.
+`implementation 'com.stellarstation.api:stellarstation-api:0.13.0'`.
 
 
 ### Set your API key


### PR DESCRIPTION
* Add `ground_station_id` and `channel_set_ids` to `SatelliteStreamRequest` for streams can be filtered on ([STS-636](https://infostellar.atlassian.net/browse/STS-636))
* Add `ground_station_id`, `channel_set_id` and `satellite_id` to `ReceiveTelemetryResponse` to allow clients to better differentiate streams (preparation for [STS-642](https://infostellar.atlassian.net/browse/STS-642))

Relates to https://github.com/infostellarinc/stellarstation/pull/6630