### PR TITLE
Increase GRPC max message size to 10MB in examples

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -39,17 +39,17 @@ jobs:
         with:
           fetch-depth: 10
       - name: Cache Gradle Modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: gradle-caches
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/wrapper
           key: gradle-wrapper
       - name: Cache Curiostack
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/curiostack
           key: ${{ runner.os }}-gradle-curiostack

--- a/examples/go/stream-benchmarker/benchmark/conn.go
+++ b/examples/go/stream-benchmarker/benchmark/conn.go
@@ -39,5 +39,9 @@ func Dial(apiKey string, apiURL string) (*grpc.ClientConn, error) {
 	return grpc.Dial(
 		apiURL,
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig)),
-		grpc.WithPerRPCCredentials(creds))
+		grpc.WithPerRPCCredentials(creds),
+		// By default, GRPC sets the max message size to 4MB, but StellarStation can support up to 10MB.
+		// If GRPC message would be received which exceeds this GRPC limit, a RESOURCE_EXHAUSTED error will be returned.
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(10*1024*1024)),
+	)
 }

--- a/examples/python/for_satellite_operators/toolkit.py
+++ b/examples/python/for_satellite_operators/toolkit.py
@@ -32,13 +32,14 @@ def get_grpc_client(api_key_path, api_url_path):
         api_key_path,
         audience=api_url_path,
         token_lifetime=60)
-    
+
     google_jwt_credentials = google_auth_jwt.OnDemandCredentials.from_signing_credentials(jwt_credentials)
 
-    # Increase grpc msg size allowance:
-    options = [('grpc.max_send_message_length', 512 * 1024 * 1024),
-               ('grpc.max_receive_message_length', 512 * 1024 * 1024)]
-    
+    # By default, GRPC sets the max message size to 4MB, but StellarStation can support up to 10MB.
+    # If GRPC message would be received which exceeds this GRPC limit, a RESOURCE_EXHAUSTED error will be returned.
+    options = [('grpc.max_send_message_length', 10 * 1024 * 1024),
+               ('grpc.max_receive_message_length', 10 * 1024 * 1024)]
+
     channel = google_auth_transport_grpc.secure_authorized_channel(
             google_jwt_credentials,
             None,

--- a/examples/rust/streamcli/src/stream.rs
+++ b/examples/rust/streamcli/src/stream.rs
@@ -71,9 +71,11 @@ pub async fn stream(args: Args) -> anyhow::Result<()> {
         .connect()
         .await?;
 
+    // By default, GRPC sets the max message size to 4MB, but StellarStation can support up to 10MB.
+    // If GRPC message would be received which exceeds this GRPC limit, a RESOURCE_EXHAUSTED error will be returned.
     let client = StellarStationServiceClient::new(channel)
-        .max_decoding_message_size(5 * 1024 * 1024)
-        .max_encoding_message_size(5 * 1024 * 1024);
+        .max_decoding_message_size(10 * 1024 * 1024)
+        .max_encoding_message_size(10 * 1024 * 1024);
 
     let ctx = CancellationToken::new();
 


### PR DESCRIPTION
The default GRPC max message size is 4MB. In our examples we used
various values for GRPC setting. The safe/correct value for
StellarStation should be 10MB, as that is the maximum we can support
internally. The client will never receive a message that is larger than
10MB.