### PR TITLE
API updates

### DIFF
--- a/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
@@ -109,6 +109,9 @@ service GroundStationService {
   // Status: ALPHA This API is under development and may not work correctly or be changed in backwards
   //         incompatible ways in the future.
   rpc OpenGroundStationStream (stream GroundStationStreamRequest) returns (stream GroundStationStreamResponse);
+
+  // For internal use only - retrieve current plan
+  rpc GetCurrentPlan (GetCurrentPlanRequest) returns (GetCurrentPlanResponse);
 }
 
 //----------------------------------------------------------------------------------------------
@@ -395,4 +398,12 @@ message SatelliteCommands {
   // immediately. After all commands have been transmitted, telemetry receive must be immediately
   // enabled again.
   repeated bytes command = 1;
+}
+
+message GetCurrentPlanRequest {
+  // Currently no payload in the request.
+}
+
+message GetCurrentPlanResponse {
+  Plan plan = 1;
 }

--- a/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
+++ b/api/src/main/proto/stellarstation/api/v1/groundstation/groundstation.proto
@@ -362,6 +362,9 @@ message SatelliteTelemetry {
   // The ID of the plan the telemetry is being sent for.
   string plan_id = 1;
 
+  // Channel set ID
+  string channel_set_id = 3;
+
   // The telemetry being sent.
   Telemetry telemetry = 2;
 }

--- a/api/src/main/proto/stellarstation/api/v1/monitoring/monitoring.proto
+++ b/api/src/main/proto/stellarstation/api/v1/monitoring/monitoring.proto
@@ -136,7 +136,7 @@ message GroundStationConfiguration {
 }
 
 // The current state of the ground station's transmitter during the operation of a pass.
-// Next ID: 8
+// Next ID: 9
 message TransmitterState {
   // The current center frequency of the transmitter, taking into account e.g., Doppler correction.
   uint64 center_frequency_hz = 1;
@@ -158,6 +158,9 @@ message TransmitterState {
 
   // The current bitrate of the transmitter
   google.protobuf.FloatValue bitrate = 7;
+
+  // Offset from the expected carrier frequency.
+  google.protobuf.FloatValue carrier_offset = 8;
 }
 
 // A current status of convolutional coding.

--- a/api/src/main/proto/stellarstation/api/v1/transport.proto
+++ b/api/src/main/proto/stellarstation/api/v1/transport.proto
@@ -121,6 +121,9 @@ message PlanMonitoringEvent {
   // The ID of the plan being monitored.
   string plan_id = 1;
 
+  // Channel set ID
+  string channel_set_id = 5;
+
   oneof Info {
     // Information about the current configuration of the ground station when beginning to execute
     // a plan. This will only be returned once at the beginning of execution. Information that is

--- a/api/src/main/proto/stellarstation/api/v1/transport.proto
+++ b/api/src/main/proto/stellarstation/api/v1/transport.proto
@@ -94,6 +94,9 @@ message StreamEvent {
   // this is always empty.
   string request_id = 1;
 
+  // Timestamp of the event occurrence
+  google.protobuf.Timestamp timestamp = 4;
+
   // An event indicating the commands in the request were sent by the ground station through its
   // radio.
   message CommandSentFromGroundStation {


### PR DESCRIPTION
Adding GetCurrentPlan for internal use
Adding new fields to be used in upcoming integrations:
* TransmitterState.carrier_offset
* StreamEvent.timestamp
* SatelliteTelemetry.channel_set_id
* PlanMonitoringEvent.channel_set_id