### PR TITLE
fix: github actions/cache v1 no longer useable, update to current

### DIFF
--- a/.github/workflows/continuous-build.yml
+++ b/.github/workflows/continuous-build.yml
@@ -39,17 +39,17 @@ jobs:
         with:
           fetch-depth: 10
       - name: Cache Gradle Modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: gradle-caches
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/wrapper
           key: gradle-wrapper
       - name: Cache Curiostack
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/curiostack
           key: ${{ runner.os }}-gradle-curiostack


### PR DESCRIPTION
[v1 is no longer supported.](https://github.com/actions/toolkit/blob/1b1e81526b802d1d641911393281c2fb45ed5f11/packages/cache/README.md)